### PR TITLE
fix: 过滤 content 中的思考内容，防止泄露到标题和历史消息

### DIFF
--- a/backend/app/streaming.py
+++ b/backend/app/streaming.py
@@ -61,10 +61,10 @@ def employee_of(conv_id: str) -> str:
 def text_of(msg) -> str:
     c = getattr(msg, "content", "")
     if isinstance(c, str):
-        return c
+        return _strip_thinking(c)
     if isinstance(c, list):
-        return "".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text")
-    return str(c)
+        return _strip_thinking("".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text"))
+    return _strip_thinking(str(c))
 
 
 def reconstruct(messages: list) -> list[dict]:
@@ -189,15 +189,52 @@ async def recover_conversations(limit: int | None = None):
         conversations.create(tid, emp, title=(first[:40] or "历史对话"), preview=first[:60])
 
 
+def _strip_thinking(text: str) -> str:
+    """过滤掉模型的思考过程标签和内容（用于标题生成等场景）。
+
+    支持常见格式：
+    - <think>...[/think] / <think>...[/think]
+    - <thinking>...</thinking>
+    - [思考]...[/思考]
+    - ~~...~~ (部分模型用删除线标记思考)
+    - 裸思考标签（如 <think>开头但没有结束标签）
+    """
+    if not text:
+        return ""
+    # 处理带结束标签的完整思考块（注意 [] 需要转义）
+    text = re.sub(r"<think>.*?\[\/think\]", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<think>.*?\[\/think\]", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<think\s*>.*?</think\s*>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<thinking\s*>.*?</thinking\s*>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"\[思考\].*?\[/思考\]", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"\[THINKING\].*?\[/THINKING\]", "", text, flags=re.DOTALL | re.IGNORECASE)
+    # 处理删除线包裹的思考
+    text = re.sub(r"(?<!~)(~~)(?!~)(.*?)(?<!~)(~~)(?!~)", r"\2", text, flags=re.DOTALL)
+    # 处理裸思考标签（开始但没有结束标签的情况）
+    # 例如：思考以换行或句子结束
+    text = re.sub(r"<think>[\s\S]*?(?=\n\n|$)", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<think>[\s\S]*?(?=\.)(?:\.|$)", "", text, flags=re.IGNORECASE)
+    # 清理多余空白
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
 async def _gen_title(conv_id: str, user_text: str, bot_text: str):
     """用模型把首轮对话提炼成 ≤16 字标题。失败静默。"""
     try:
+        # 过滤思考内容
+        clean_bot_text = _strip_thinking(bot_text)
+        if not clean_bot_text.strip():
+            clean_bot_text = bot_text
+
         m = _init_model(os.environ.get("MODEL_NAME", ""))
         prompt = ("请根据以下对话生成一个不超过16个字的中文标题，"
                   "直接输出标题文字，不要引号、不要解释、不要句号。\n"
-                  f"用户：{user_text[:200]}\n助手：{bot_text[:200]}")
+                  f"用户：{user_text[:200]}\n助手：{clean_bot_text[:200]}")
         r = await m.ainvoke([HumanMessage(content=prompt)])
-        title = r.content.strip().strip('"').strip("“”").strip("《》")[:24]
+        title = r.content.strip().strip('"').strip("\u201c\u201d").strip("\u300a\u300b")[:24]
+        # 二次过滤标题中的思考标签
+        title = _strip_thinking(title)
         if title:
             conversations.set_title(conv_id, title)
     except Exception:

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -261,7 +261,12 @@ function setStage(id, status, detail) {
 }
 
 /* ---------- SSE 流式解析 ---------- */
+let inThinking = false  // 思考状态标记
+let thinkContent = ''  // 当前思考内容
+
 async function readStream(resp, msgIdx) {
+  inThinking = false
+  thinkContent = ''
   const reader = resp.body.getReader()
   const dec = new TextDecoder()
   let buf = ''
@@ -293,15 +298,100 @@ function handleEvent(ev, msgIdx) {
     }
   } else if (ev.type === 'thinking') {
     if (!msg.trace) msg.trace = []
-    let box = msg.trace.find(t => t.type === 'think' && !t._closed)
-    if (!box) { box = { type: 'think', content: '' }; msg.trace.push(box) }
+    let box = msg.trace.find(t => t.type === 'think' && !t._closed && t.source === 'event')
+    if (!box) { box = { type: 'think', content: '', source: 'event' }; msg.trace.push(box) }
     box.content += ev.content
     msg.trace = [...msg.trace]
     scrollToBottom()
   } else if (ev.type === 'token') {
     if (!msg._md) msg._md = ''
-    msg._md += ev.content
-    msg.html = renderMd(msg._md)
+    let content = ev.content
+    // 检测思考标签
+    const startMatch = content.match(/<think>|\[思考\]/i)
+    const endMatch = content.match(/\[\/think\]|<\/think\s*>/i)
+    if (startMatch && endMatch) {
+      // 同时有开始和结束标签，提取思考内容并保留标签后的内容
+      const thinkStartIdx = content.search(/<think>|\[思考\]/i)
+      const thinkEndIdx = content.search(/\[\/think\]|<\/think\s*>/i)
+      const thinkPart = content.slice(thinkStartIdx, thinkEndIdx)
+      // 提取思考内容（去掉标签）
+      const thinkText = thinkPart.replace(/<think>|\[思考\]|\[\/think\]|<\/think\s*>/gi, '')
+      if (thinkText) {
+        if (!msg.trace) msg.trace = []
+        let thinkBox = msg.trace.find(t => t.type === 'think' && !t._closed && t.source === 'token')
+        if (!thinkBox) {
+          thinkBox = { type: 'think', content: '', source: 'token' }
+          msg.trace.push(thinkBox)
+        }
+        thinkBox.content += thinkText
+        msg.trace = [...msg.trace]
+      }
+      // 保留标签后的内容
+      const afterIdx = Math.max(
+        content.indexOf('>', thinkEndIdx),
+        content.lastIndexOf(']', content.length)
+      )
+      content = content.slice(afterIdx + 1)
+      inThinking = false
+    } else if (startMatch) {
+      // 只有开始标签，提取开始标签后的思考内容
+      const thinkStartIdx = content.search(/<think>|\[思考\]/i)
+      const thinkPart = content.slice(thinkStartIdx + 6)  // 去掉开始标签
+      const thinkText = thinkPart.replace(/<think>|\[思考\]|\[\/think\]|<\/think\s*>/gi, '')
+      if (thinkText) {
+        if (!msg.trace) msg.trace = []
+        let thinkBox = msg.trace.find(t => t.type === 'think' && !t._closed && t.source === 'token')
+        if (!thinkBox) {
+          thinkBox = { type: 'think', content: '', source: 'token' }
+          msg.trace.push(thinkBox)
+        }
+        thinkBox.content += thinkText
+        msg.trace = [...msg.trace]
+      }
+      inThinking = true
+      content = ''
+    } else if (inThinking) {
+      // 在思考状态中
+      if (endMatch) {
+        // 遇到结束标签，提取结束标签前的思考内容
+        const thinkEndIdx = content.search(/\[\/think\]|<\/think\s*>/i)
+        const thinkText = content.slice(0, thinkEndIdx).replace(/<think>|\[思考\]|\[\/think\]|<\/think\s*>/gi, '')
+        if (thinkText) {
+          if (!msg.trace) msg.trace = []
+          let thinkBox = msg.trace.find(t => t.type === 'think' && !t._closed && t.source === 'token')
+          if (!thinkBox) {
+            thinkBox = { type: 'think', content: '', source: 'token' }
+            msg.trace.push(thinkBox)
+          }
+          thinkBox.content += thinkText
+          msg.trace = [...msg.trace]
+        }
+        // 保留标签后的内容
+        const afterIdx = Math.max(
+          content.indexOf('>', thinkEndIdx),
+          content.lastIndexOf(']', content.length)
+        )
+        content = content.slice(afterIdx + 1)
+        inThinking = false
+      } else {
+        const thinkText = content.replace(/<think>|\[思考\]|\[\/think\]|<\/think\s*>/gi, '')
+        if (thinkText) {
+          if (!msg.trace) msg.trace = []
+          let thinkBox = msg.trace.find(t => t.type === 'think' && !t._closed && t.source === 'token')
+          if (!thinkBox) {
+            thinkBox = { type: 'think', content: '', source: 'token' }
+            msg.trace.push(thinkBox)
+          }
+          thinkBox.content += thinkText
+          msg.trace = [...msg.trace]
+        }
+        content = ''
+      }
+    }
+    if (content) {
+      msg._md += content
+      msg.html = renderMd(msg._md)
+    }
     msg.content = ''
     messages.value = [...messages.value]
     scrollToBottom()


### PR DESCRIPTION
## 背景
   模型在返回 `content` 时，会将思考过程（如 `<think>...</think>`）一并返回，
   导致以下问题：
   - 思考内容直接暴露给用户
   - 思考内容影响对话标题的生成
   - 思考内容污染历史消息记录

   ## 解决方案

   ### 后端过滤（`streaming.py`）
   - 新增 `_strip_thinking()` 函数，统一过滤思考标签
   - `text_of()` - 读取历史消息时过滤
   - `_gen_title()` - 生成标题时过滤
   - 支持格式：`<think>...</think>`、`<think>...`、`<think>\n...`

   ### 前端提取（`ChatView.vue`）
   - 流式处理时自动提取 token 中的思考内容
   - 思考内容显示在 "思考 / 工具" 折叠区域
   - 主消息区域只展示最终回复

   ## 影响范围
   - ✅ 对话标题：正确反映对话内容
   - ✅ 历史消息：干净无污染