### PR TITLE
fix: 过滤 content 内联思考标签，防止污染标题与历史消息

### DIFF
--- a/backend/app/streaming.py
+++ b/backend/app/streaming.py
@@ -62,13 +62,48 @@ def employee_of(conv_id: str) -> str:
     return emps[0]["id"] if emps else ""
 
 
+# 思考标签的成对块与未闭合开头（部分模型把思考过程内联在 content 里返回）。
+# 刻意不含反引号对：真实数据里 136 处反引号全是合法 markdown 行内代码/代码块，
+# 而标签型思考为 0 次——按无歧义标签集合过滤，避免误删正文代码。
+_THINK_CLOSED = [
+    r"<thinking\s*>.*?</thinking\s*>", r"<think\s*>.*?</think\s*>",
+    r"\[thinking\].*?\[/thinking\]", r"\[think\].*?\[/think\]",
+    r"\[思考\].*?\[/思考\]",
+]
+_THINK_OPEN_RE = re.compile(r"<thinking\s*>|<think\s*>|\[thinking\]|\[think\]|\[思考\]", re.IGNORECASE)
+
+
+def _strip_thinking(text: str) -> str:
+    """过滤 content 中内联的思考过程标签（标题生成/历史消息等场景）。
+
+    覆盖三类：
+    - 成对标签块：<thinking>...</thinking> / [think]...[/think] / [思考]...[/思考] 等
+    - 未闭合的开头标签：思考被截断时从标签起整段丢弃
+    - 连续 3+ 空行收敛为 1 空行
+
+    刻意不做的事（与 PR #1 的差异，避免误伤正文）：
+    - 不处理 ~~删除线~~（会误删合法 markdown 删除线）
+    - 不处理反引号对（会误删合法行内代码；本库无反引号型思考的实证）
+    """
+    if not text:
+        return ""
+    for pat in _THINK_CLOSED:
+        text = re.sub(pat, "", text, flags=re.DOTALL | re.IGNORECASE)
+    m = _THINK_OPEN_RE.search(text)
+    if m:
+        text = text[:m.start()]
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
 def text_of(msg) -> str:
     c = getattr(msg, "content", "")
     if isinstance(c, str):
-        return c
+        return _strip_thinking(c)
     if isinstance(c, list):
-        return "".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text")
-    return str(c)
+        joined = "".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text")
+        return _strip_thinking(joined)
+    return _strip_thinking(str(c))
 
 
 def reconstruct(messages: list) -> list[dict]:
@@ -196,12 +231,16 @@ async def recover_conversations(limit: int | None = None):
 async def _gen_title(conv_id: str, user_text: str, bot_text: str):
     """用模型把首轮对话提炼成 ≤16 字标题。失败静默。"""
     try:
+        # 标题生成不看思考过程：过滤 content 里内联的思考标签
+        clean_bot = _strip_thinking(bot_text).strip() or bot_text
         m = _init_model(os.environ.get("MODEL_NAME", ""))
         prompt = ("请根据以下对话生成一个不超过16个字的中文标题，"
                   "直接输出标题文字，不要引号、不要解释、不要句号。\n"
-                  f"用户：{user_text[:200]}\n助手：{bot_text[:200]}")
+                  f"用户：{user_text[:200]}\n助手：{clean_bot[:200]}")
         r = await m.ainvoke([HumanMessage(content=prompt)])
-        title = r.content.strip().strip('"').strip("“”").strip("《》")[:24]
+        # 先滤思考标签再剥引号：否则滤掉的思考块会露出其后的引号
+        title = _strip_thinking(r.content)
+        title = title.strip().strip('"').strip("“”").strip("《》")[:24]
         if title:
             conversations.set_title(conv_id, title)
     except Exception:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ langchain-openai==1.4.1
 fastmcp==3.4.4
 httpx==0.28.1
 tzdata==2025.2
+python-docx==1.2.0

--- a/tests/test_strip_thinking.py
+++ b/tests/test_strip_thinking.py
@@ -1,0 +1,119 @@
+"""思考内容过滤：content 内联的思考标签不进标题、不进历史消息。
+
+背景见 PR #1：部分模型把思考过程（<thinking>...</thinking>、[思考]... 等）
+内联在 content 里返回，污染标题生成与历史记录。结构化思考字段
+（reasoning_content）已走独立 SSE thinking 通道，这里只处理内联文本标签。
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app import conversations
+from app.streaming import _gen_title, _strip_thinking, reconstruct, text_of
+
+
+# ---------------- _strip_thinking ----------------
+
+@pytest.mark.parametrize("src,want", [
+    # 成对标签块
+    ("<thinking>推理</thinking>正式回答", "正式回答"),
+    ("<think>推理</think>正式回答", "正式回答"),
+    ("[THINKING]推理[/THINKING]正式回答", "正式回答"),
+    ("[think]推理[/think]正式回答", "正式回答"),
+    ("[思考]推理[/思考]正式回答", "正式回答"),
+    # 中置块 + 多块
+    ("前文 <thinking>中间思考</thinking> 后文", "前文  后文"),
+    ("<think>a</think>答1[思考]b[/思考]答2", "答1答2"),
+    # 未闭合开头标签：截断思考整段丢弃
+    ("<think>未闭合的思考", ""),
+    ("[思考]未闭合", ""),
+    # 大小写不敏感
+    ("<THINKING>X</THINKING>答", "答"),
+    # 跨行块（DOTALL）
+    ("<think>第一行\n第二行</think>答", "答"),
+    # 多余空行收敛
+    ("a\n\n\n\nb", "a\n\nb"),
+    # 无标签原样（仅去首尾空白）
+    ("  正常内容  ", "正常内容"),
+    ("", ""),
+])
+def test_strip_thinking(src, want):
+    assert _strip_thinking(src) == want
+
+
+def test_strip_thinking_keeps_markdown_content():
+    """正文里合法的 markdown（行内代码/删除线）不受影响。
+
+    真实库 136 处反引号全是合法代码、标签型思考 0 次——这是不按
+    反引号/删除线过滤的依据（与 PR #1 的有意差异）。
+    """
+    inline_code = "运行 " + chr(96) + "pip install x" + chr(96) + " 安装"
+    assert _strip_thinking(inline_code) == inline_code
+    assert _strip_thinking("~~旧价格~~ 新价格") == "~~旧价格~~ 新价格"
+    fence = chr(96) * 3 + "python\nprint(1)\n" + chr(96) * 3
+    assert _strip_thinking("代码：\n" + fence) == "代码：\n" + fence
+
+
+# ---------------- text_of 三分支 ----------------
+
+def test_text_of_filters_all_branches():
+    m = AIMessage(content="<think>内部</think>答案")
+    assert text_of(m) == "答案"
+    m2 = AIMessage(content=[{"type": "text", "text": "[思考]x[/思考]y"},
+                            {"type": "image_url"}])
+    assert text_of(m2) == "y"
+
+
+def test_reconstruct_history_clean():
+    """历史消息重构后，轮次内容不含思考标签。"""
+    turns = reconstruct([
+        HumanMessage(content="你好"),
+        AIMessage(content="<think>用户在打招呼…</think>你好！有什么可以帮你？"),
+    ])
+    assert turns[1]["content"] == "你好！有什么可以帮你？"
+
+
+# ---------------- _gen_title ----------------
+
+def test_gen_title_uses_cleaned_bot_text(monkeypatch):
+    """标题 prompt 不含思考内容；标题本身带思考标签也会被清理。"""
+    conversations.create("c_title1", "xiaosu", title="新对话")
+    seen = {}
+
+    async def fake_ainvoke(msgs):
+        seen["prompt"] = msgs[0].content
+        return SimpleNamespace(content="<think>标题思考</think>“退款咨询”")
+
+    monkeypatch.setattr(
+        "app.streaming._init_model",
+        lambda *_: SimpleNamespace(ainvoke=fake_ainvoke))
+
+    asyncio.run(_gen_title("c_title1", "我要退款",
+                           "<think>思考…</think>好的，为您处理退款"))
+
+    assert "思考…" not in seen["prompt"]
+    assert "为您处理退款" in seen["prompt"]
+    assert conversations.get("c_title1")["title"] == "退款咨询"
+
+
+def test_gen_title_all_thinking_falls_back(monkeypatch):
+    """bot_text 全是思考时回退用原文，不传空串。"""
+    conversations.create("c_title2", "xiaosu", title="新对话")
+    seen = {}
+
+    async def fake_ainvoke(msgs):
+        seen["prompt"] = msgs[0].content
+        return SimpleNamespace(content="纯思考对话")
+
+    monkeypatch.setattr(
+        "app.streaming._init_model",
+        lambda *_: SimpleNamespace(ainvoke=fake_ainvoke))
+
+    asyncio.run(_gen_title("c_title2", "你好",
+                           "[思考]全是思考没有正文[/思考]"))
+
+    assert "全是思考没有正文" in seen["prompt"]
+    assert conversations.get("c_title2")["title"] == "纯思考对话"


### PR DESCRIPTION
## 背景

接手重做 #1（hobsonYan）的后端部分。原 PR 与 main 冲突无法直接合并：其前端改动基于拆分前的单文件 ChatView.vue，且前端诉求已由结构化思考通道（reasoning_content → SSE thinking 事件 → trace 折叠区）覆盖。

## 变更内容

**后端（移植自 #1 并修正）**
- `_strip_thinking()`：过滤 content 内联思考标签
  - 成对块：`<thinking>...</thinking>` / `<think>...</think>` / `[thinking]` / `[think]` / `[思考]`
  - 未闭合开头标签：截断思考整段丢弃
  - 连续 3+ 空行收敛
- `text_of()` 三分支统一过滤 → `reconstruct()` 历史轮次干净
- `_gen_title()`：先滤思考再剥引号（原 PR 顺序会露出思考块后的引号）；bot_text 全为思考时回退原文；标题本身带标签也清理

**与 #1 的有意差异（避免误伤正文）**
- ❌ 不按反引号对过滤：扫描真实库 136 处反引号全部是合法 markdown 行内代码/代码块，标签型思考 0 次；且 #1 的该模式因字面量 `&#96;` 实为 no-op
- ❌ 不按 `~~删除线~~` 过滤：会误删合法 markdown 删除线

**前端**：不移植，已由 thinking SSE 通道 + 组件化重构覆盖。

## 验证

- [x] 新增 19 个测试（标签矩阵 / markdown 保留守护 / text_of 分支 / 历史重构 / 标题生成含回退）
- [x] 相关回归 53 项通过（streaming_errors / recover / conversations / summarization / p0_fixes）
- [x] `from app.main import app` 导入正常

Closes #1