### PR TITLE
docs: 补录 CHANGELOG 0.4.0，修正 README 版本号

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.4.0 (2026-08-27)
+
+### 重磅变更：数据库迁移 PostgreSQL
+
+- **存储后端由 SQLite 整体切换为 PostgreSQL**（#3）：面向多用户并发与网络访问的企业共享部署场景，SQLite 单写锁不再适用
+- 新增 `app/db.py` 双方言数据访问层：psycopg 连接池 + SQL 方言翻译（`INSERT OR IGNORE→ON CONFLICT`、`AUTOINCREMENT→IDENTITY`、`?→%s`），业务代码保持统一写法；`DB_BACKEND=sqlite` 分支仅测试夹具使用
+- checkpointer / store 切换为官方 `langgraph-checkpoint-postgres`（`AsyncPostgresSaver` / `AsyncPostgresStore`），`streaming.py` 启动恢复兼容 PG 表结构
+- catalog / conversations / traces / approvals / ontology 全部接入访问层；修复 users 主键秒级时间戳碰撞问题
+- `docker-compose.yml` 新增 `db` 服务（postgres:16-alpine，首启自动建 7 个业务库）；新增 `scripts/init_postgres.sql` 与幂等建库脚本 `scripts/init_postgres.sh`（支持 `--host/--port/--prefix`）
+- `backup.sh` 改用 `pg_dump`（支持 `PGBIN` 指定路径）；requirements 增补 psycopg / checkpoint-postgres
+- **升级注意**：`DB_BACKEND=postgres` + `POSTGRES_*` 环境变量必填（见 `.env.example`），存量 SQLite 数据需自行迁入
+
+### 新增
+
+- 运行评估功能：每条回答 👍/👎 反馈（含点踩原因浮层），管理员评估仪表盘（指标卡片 + 日趋势 + Top 工具 + 反馈明细，`AdminEvaluation.vue`）；SSE 新增 `message_end` 事件携带反馈关联 ID
+- 对话附件上传：`/api/conversations/{id}/attachments`（单文件 20MB 限制），附件路径注入消息文本，前端输入栏支持附件选择与消息内附件标签
+- 运行 / 工具错误在对话页可见化，用户不再只看到静默失败
+- 前端聊天视图组件化：ChatView 拆分为 InputBar / ChatMessage / PipelineSidebar / ConversationSidebar / ReasonPopover
+- 开源就绪：CI（后端 pytest + 前端构建）、issue 模板、PR 模板、CODE_OF_CONDUCT / SECURITY / CONTRIBUTING 社区文件
+- 英文 README（`README.en.md`），中英双语切换；LICENSE 修复为标准 MIT 全文，GitHub 正确识别
+
+### 修复
+
+- 过滤 `content` 内联思考标签，防止污染会话标题生成与历史消息展示（#2）
+- 恢复消息评价按钮——聊天视图组件拆分时遗漏了 `message_end` 事件处理导致 `run_id` 为空
+- 可靠性修复：文档工具数据按用户隔离、trace 写入失败可观测（不再静默吞错）、退款审批双路径补充测试
+- 修复全新环境启动与退款审批路径的 bug（开源前回归）
+
+---
+
 ## 0.3.1 (2026-08-04)
 
 ### 新增

--- a/README.en.md
+++ b/README.en.md
@@ -243,7 +243,7 @@ Quick local start: `docker compose up -d db` (7 databases are created automatica
 | `JWT_EXPIRE_HOURS` | `24` | Token lifetime (hours) |
 | `LOG_LEVEL` / `LOG_FILE` | `INFO` / empty | Log level / file path |
 | `DB_BACKEND` / `POSTGRES_*` | `postgres` | Database backend and connection params (host/port/user/password/db prefix) |
-| `APP_VERSION` | `0.3.1` | Printed at /health and in logs |
+| `APP_VERSION` | `0.4.0` | Printed at /health and in logs |
 | `PRODUCT_WIKI_DIR` | `product-wiki/` | Markdown product-KB directory for the sales skill |
 | `RAGFLOW_BASE_URL` / `RAGFLOW_API_KEY` / `RAGFLOW_DATASET_IDS` | — | RAGFlow integration (optional) |
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ UniEmployee/
 | `JWT_EXPIRE_HOURS` | `24` | token 有效期（小时） |
 | `LOG_LEVEL` / `LOG_FILE` | `INFO` / 空 | 日志级别 / 文件路径 |
 | `DB_BACKEND` / `POSTGRES_*` | `postgres` | 数据库后端与连接参数（host/port/user/password/db 前缀） |
-| `APP_VERSION` | `0.3.1` | 打印在 /health 与日志 |
+| `APP_VERSION` | `0.4.0` | 打印在 /health 与日志 |
 | `PRODUCT_WIKI_DIR` | `product-wiki/` | 销售技能的产品知识库 markdown 目录 |
 | `RAGFLOW_BASE_URL` / `RAGFLOW_API_KEY` / `RAGFLOW_DATASET_IDS` | — | RAGFlow 知识库接入（可选） |
 


### PR DESCRIPTION
## 变更内容
- **CHANGELOG.md** 新增 0.4.0 (2026-08-27) 条目，覆盖 0.3.1 之后全部变更：
  - 重磅变更：SQLite → PostgreSQL 迁移（#3），含 db.py 双方言访问层、checkpointer/store 切换、docker db 服务与建库脚本、升级注意事项
  - 新增：运行评估（👍/👎 + 管理员仪表盘）、对话附件上传、错误可见化、聊天视图组件化、开源就绪（CI/社区文件）、英文 README
  - 修复：内联思考标签过滤（#2）、评价按钮恢复、可靠性修复、全新环境启动与退款审批 bug
- **README.md / README.en.md**：环境变量表 APP_VERSION 默认值 0.3.1 → 0.4.0，与 main.py 代码默认值对齐

## 验证
- 纯文档变更，无代码改动
- 条目内容逐条核对自 git log（0.3.1 之后全部提交）