### PR TITLE
feat: 本体关系图谱（力导向可视化）+ 修复类型编辑保存 bug

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.9",
+        "echarts": "^6.1.0",
         "marked": "^18.0.7",
         "naive-ui": "^2.40.3",
         "pinia": "^2.3.0",
@@ -1176,6 +1177,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmmirror.com/entities/-/entities-7.0.1.tgz",
@@ -1755,6 +1766,12 @@
       "integrity": "sha512-M8RGFoKtZ8dF+iwJfAJTOH/SM4KluKOKRJpjCMhI8bG3qB74zrFoArKZ62ll0Fr3mqkMJiQOmWYkdYgDeITYQg==",
       "license": "MIT"
     },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/vdirs": {
       "version": "0.1.8",
       "resolved": "https://registry.npmmirror.com/vdirs/-/vdirs-0.1.8.tgz",
@@ -1932,6 +1949,15 @@
       },
       "peerDependencies": {
         "vue": "^3.0.11"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "echarts": "^6.1.0",
     "marked": "^18.0.7",
     "naive-ui": "^2.40.3",
     "pinia": "^2.3.0",

--- a/frontend/src/views/OntologyView.vue
+++ b/frontend/src/views/OntologyView.vue
@@ -56,6 +56,17 @@
         <n-data-table :columns="relColumns" :data="relations" size="small" :pagination="relPagination" :row-key="r => r.id" />
       </n-tab-pane>
 
+      <!-- 关系图谱 -->
+      <n-tab-pane name="graph" tab="关系图谱">
+        <div class="onto-toolbar">
+          <span class="graph-hint">节点按实体类型着色，连线为关系（中文名）；拖拽节点调整布局，滚轮缩放，点击节点查看详情</span>
+          <div class="spacer" />
+          <n-button size="small" @click="relayoutGraph">重新布局</n-button>
+        </div>
+        <div v-show="relations.length" ref="graphRef" class="onto-graph"></div>
+        <n-empty v-if="!relations.length" description="暂无关系数据，先在「业务关系」中创建" size="large" style="padding:60px 0" />
+      </n-tab-pane>
+
       <!-- 类型定义 -->
       <n-tab-pane name="schema" tab="类型定义">
         <div class="onto-schema">
@@ -145,9 +156,9 @@
     </n-modal>
 
     <!-- 实体类型 新建 弹窗 -->
-    <n-modal v-model:show="typeModal" preset="card" title="新建实体类型" style="width:560px;max-width:92vw">
+    <n-modal v-model:show="typeModal" preset="card" :title="editingType ? '编辑实体类型' : '新建实体类型'" style="width:560px;max-width:92vw">
       <n-form label-placement="left" :label-width="90" size="small">
-        <n-form-item label="代码"><n-input v-model:value="typeForm.code" placeholder="唯一标识，如 customer" /></n-form-item>
+        <n-form-item label="代码"><n-input v-model:value="typeForm.code" :disabled="!!editingType" placeholder="唯一标识，如 customer" /></n-form-item>
         <n-form-item label="名称"><n-input v-model:value="typeForm.name" /></n-form-item>
         <n-form-item label="图标"><n-input v-model:value="typeForm.icon" placeholder="emoji，如 🤝" /></n-form-item>
         <n-form-item label="描述"><n-input v-model:value="typeForm.description" /></n-form-item>
@@ -164,9 +175,9 @@
     </n-modal>
 
     <!-- 关系类型 新建 弹窗 -->
-    <n-modal v-model:show="rtModal" preset="card" title="新建关系类型" style="width:560px;max-width:92vw">
+    <n-modal v-model:show="rtModal" preset="card" :title="editingRt ? '编辑关系类型' : '新建关系类型'" style="width:560px;max-width:92vw">
       <n-form label-placement="left" :label-width="90" size="small">
-        <n-form-item label="代码"><n-input v-model:value="rtForm.code" placeholder="唯一标识，如 follow_up" /></n-form-item>
+        <n-form-item label="代码"><n-input v-model:value="rtForm.code" :disabled="!!editingRt" placeholder="唯一标识，如 follow_up" /></n-form-item>
         <n-form-item label="名称"><n-input v-model:value="rtForm.name" /></n-form-item>
         <n-form-item label="来源类型">
           <n-select v-model:value="rtForm.from_type" :options="typeOptions" filterable />
@@ -188,10 +199,16 @@
 </template>
 
 <script setup>
-import { ref, computed, h, onMounted } from 'vue'
+import { ref, computed, h, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useMessage } from 'naive-ui'
+import * as echarts from 'echarts/core'
+import { GraphChart } from 'echarts/charts'
+import { TooltipComponent, LegendComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
 import { useAuthStore } from '../stores/auth.js'
 import api from '../api.js'
+
+echarts.use([GraphChart, TooltipComponent, LegendComponent, CanvasRenderer])
 
 const msg = useMessage()
 const auth = useAuthStore()
@@ -254,8 +271,10 @@ const relationModal = ref(false)
 const relationForm = ref({ from_id: null, to_id: null, relation_type: null })
 const typeModal = ref(false)
 const typeForm = ref({})
+const editingType = ref(null)
 const rtModal = ref(false)
 const rtForm = ref({})
+const editingRt = ref(null)
 
 const entityById = id => entities.value.find(e => e.id === id)
 const relName = id => entityById(id)?.name || `#${id}`
@@ -350,6 +369,7 @@ async function delRelation(id) {
 }
 
 function openTypeModal(t) {
+  editingType.value = t || null
   typeForm.value = {
     code: t?.code || '', name: t?.name || '', icon: t?.icon || '',
     description: t?.description || '', attrs: JSON.stringify(t?.attrs || [], null, 1) || '[]',
@@ -359,7 +379,11 @@ function openTypeModal(t) {
 async function saveType() {
   try {
     const body = { ...typeForm.value, attrs: JSON.parse(typeForm.value.attrs || '[]') }
-    await api.post('/admin/ontology/entity-types', body)
+    if (editingType.value) {
+      await api.put(`/admin/ontology/entity-types/${editingType.value.id}`, body)
+    } else {
+      await api.post('/admin/ontology/entity-types', body)
+    }
     msg.success('已保存')
     typeModal.value = false
     reloadAll()
@@ -368,6 +392,7 @@ async function saveType() {
   }
 }
 function openRtModal(t) {
+  editingRt.value = t || null
   rtForm.value = {
     code: t?.code || '', name: t?.name || '', from_type: t?.from_type || null,
     to_type: t?.to_type || null, cardinality: t?.cardinality || 'm:n', description: t?.description || '',
@@ -376,7 +401,11 @@ function openRtModal(t) {
 }
 async function saveRt() {
   try {
-    await api.post('/admin/ontology/relation-types', rtForm.value)
+    if (editingRt.value) {
+      await api.put(`/admin/ontology/relation-types/${editingRt.value.id}`, rtForm.value)
+    } else {
+      await api.post('/admin/ontology/relation-types', rtForm.value)
+    }
     msg.success('已保存')
     rtModal.value = false
     reloadAll()
@@ -386,6 +415,99 @@ async function saveRt() {
 }
 
 onMounted(reloadAll)
+
+// ---------------- 关系图谱 ----------------
+const graphRef = ref(null)
+let chart = null
+let graphEntities = []
+let graphObserver = null
+
+function buildGraphOption() {
+  const ets = schema.value.entity_types || []
+  const categories = ets.map(t => ({ name: t.name }))
+  const catIdx = Object.fromEntries(ets.map((t, i) => [t.code, i]))
+  const degree = {}
+  relations.value.forEach(r => {
+    degree[r.from_id] = (degree[r.from_id] || 0) + 1
+    degree[r.to_id] = (degree[r.to_id] || 0) + 1
+  })
+  const nodes = graphEntities.map(e => ({
+    id: String(e.id),
+    name: e.name,
+    entityType: e.entity_type,
+    category: catIdx[e.entity_type],
+    symbolSize: Math.min(24 + (degree[e.id] || 0) * 4, 56),
+    value: degree[e.id] || 0,
+    itemStyle: catIdx[e.entity_type] === undefined ? { color: '#909399' } : undefined,
+  }))
+  const entMap = Object.fromEntries(graphEntities.map(e => [String(e.id), e]))
+  const links = relations.value.map(r => ({
+    source: String(r.from_id),
+    target: String(r.to_id),
+    value: relTypeName(r.relation_type),
+    lineStyle: { color: 'source', curveness: 0.15 },
+  }))
+  return {
+    tooltip: {
+      confine: true,
+      formatter: p => {
+        if (p.dataType === 'edge') {
+          const from = entMap[p.data.source]?.name || p.data.source
+          const to = entMap[p.data.target]?.name || p.data.target
+          return `${from} —${p.data.value}→ ${to}`
+        }
+        return `<b>${p.data.name}</b><br/>类型：${entityTypeName(p.data.entityType)}<br/>关联数：${p.data.value}`
+      },
+    },
+    legend: [{ data: categories.map(c => c.name), bottom: 0, type: 'scroll' }],
+    series: [{
+      type: 'graph',
+      layout: 'force',
+      roam: true,
+      draggable: true,
+      categories,
+      data: nodes,
+      links,
+      force: { repulsion: 320, edgeLength: [60, 130], gravity: 0.08 },
+      label: { show: true, position: 'right', fontSize: 12 },
+      labelLayout: { hideOverlap: true },
+      edgeLabel: { show: true, fontSize: 10, color: '#999', formatter: p => p.data.value },
+      emphasis: { focus: 'adjacency', lineStyle: { width: 3 } },
+      scaleLimit: { min: 0.3, max: 4 },
+    }],
+  }
+}
+
+async function refreshGraphData() {
+  graphEntities = (await api.get('/admin/ontology/entities')).data.items
+  if (chart) chart.setOption(buildGraphOption())
+}
+
+async function ensureGraph() {
+  await nextTick()
+  if (!graphRef.value || chart) return
+  chart = echarts.init(graphRef.value)
+  chart.on('click', p => { if (p.dataType === 'node') openEntityDetail(Number(p.data.id)) })
+  graphObserver = new ResizeObserver(() => chart && chart.resize())
+  graphObserver.observe(graphRef.value)
+  await refreshGraphData()
+}
+
+function relayoutGraph() {
+  if (!chart) return
+  chart.dispose()
+  chart = null
+  ensureGraph()
+}
+
+watch(activeTab, t => { if (t === 'graph') ensureGraph() })
+watch(relations, () => { if (chart) refreshGraphData() })
+
+onBeforeUnmount(() => {
+  graphObserver?.disconnect()
+  chart?.dispose()
+  chart = null
+})
 </script>
 
 <style scoped>
@@ -407,4 +529,6 @@ onMounted(reloadAll)
 .onto-detail-rel { margin-top: 16px; }
 .onto-rel-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; }
 .onto-rel-text { flex: 1; font-size: 13px; }
+.onto-graph { height: 560px; border: 1px solid #e0e0e6; border-radius: 8px; }
+.graph-hint { color: #888; font-size: 12px; }
 </style>


### PR DESCRIPTION
## 变更内容

### 1. 新增「关系图谱」tab
本体页新增关系可视化图谱（echarts 按需引入 Graph/Tooltip/Legend）：
- **力导向布局**：实体为节点、关系为连线，自动排布
- **按实体类型着色**：底部图例可点选过滤某类实体
- **连线显示中文关系名**（隶属于/担任/跟进…），悬停节点/连线显示详情 tooltip
- **节点大小随关联数**变化，悬停聚焦邻接（emphasis adjacency）
- **交互**：拖拽节点调整布局、滚轮缩放、画布平移、点击节点打开实体详情抽屉、重新布局按钮
- 数据变更（新建/删除实体或关系）后图谱自动刷新；组件卸载时清理 chart 与 ResizeObserver

### 2. 修复类型编辑保存 bug
实体类型/关系类型的编辑弹窗保存时只调了 POST（创建接口），从未调用已有的 PUT 更新接口——编辑自定义类型实际会报"code 已存在"。现按新建/编辑分别走 POST/PUT，编辑时 code 字段禁用（后端更新不支持改 code），弹窗标题区分新建/编辑。

注：系统预置类型（system 租户）仍为只读，此为设计约束（保护全局 schema），前端显示"只读"。

## 验证
- 前端构建通过（npx vite build）
- echarts 按需引入（echarts/core + GraphChart），未引入全量包