### PR TITLE
feat: 开放系统预置类型编辑与删除

### DIFF
--- a/backend/app/ontology.py
+++ b/backend/app/ontology.py
@@ -354,11 +354,6 @@ def list_schema(tenant_id: str) -> dict:
     return {"entity_types": ets, "relation_types": rts}
 
 
-def _is_system(con, table, id_, tenant_id):
-    row = con.execute(f"SELECT tenant_id FROM {table} WHERE id=?", (id_,)).fetchone()
-    return row is None or row["tenant_id"] == "system" and tenant_id != "system"
-
-
 def create_entity_type(tenant_id: str, data: dict) -> int:
     code, name = (data.get("code") or "").strip(), (data.get("name") or "").strip()
     if not code or not name:
@@ -386,9 +381,6 @@ def create_entity_type(tenant_id: str, data: dict) -> int:
 
 def update_entity_type(tenant_id: str, id_: int, data: dict) -> None:
     con = _conn()
-    if _is_system(con, "entity_types", id_, tenant_id):
-        con.close()
-        raise ValueError("系统预置类型不可修改")
     attrs = json.dumps(data.get("attrs") or [], ensure_ascii=False)
     con.execute(
         "UPDATE entity_types SET name=?, description=?, icon=?, attrs=?, updated_at=? WHERE id=?",
@@ -399,9 +391,6 @@ def update_entity_type(tenant_id: str, id_: int, data: dict) -> None:
 
 def delete_entity_type(tenant_id: str, id_: int) -> None:
     con = _conn()
-    if _is_system(con, "entity_types", id_, tenant_id):
-        con.close()
-        raise ValueError("系统预置类型不可删除")
     con.execute("UPDATE entity_types SET deleted_at=? WHERE id=? AND deleted_at IS NULL",
                 (_now(), id_))
     con.commit()
@@ -435,22 +424,18 @@ def create_relation_type(tenant_id: str, data: dict) -> int:
 
 def update_relation_type(tenant_id: str, id_: int, data: dict) -> None:
     con = _conn()
-    if _is_system(con, "relation_types", id_, tenant_id):
-        con.close()
-        raise ValueError("系统预置关系类型不可修改")
+    # from_type/to_type NOT NULL：未传时保留原值（COALESCE）
     con.execute(
-        "UPDATE relation_types SET name=?, from_type=?, to_type=?, cardinality=?, description=?, updated_at=? WHERE id=?",
+        "UPDATE relation_types SET name=?, from_type=COALESCE(?, from_type), to_type=COALESCE(?, to_type),"
+        " cardinality=COALESCE(?, cardinality), description=?, updated_at=? WHERE id=?",
         (data.get("name"), data.get("from_type"), data.get("to_type"),
-         data.get("cardinality") or "m:n", data.get("description"), _now(), id_))
+         data.get("cardinality"), data.get("description"), _now(), id_))
     con.commit()
     con.close()
 
 
 def delete_relation_type(tenant_id: str, id_: int) -> None:
     con = _conn()
-    if _is_system(con, "relation_types", id_, tenant_id):
-        con.close()
-        raise ValueError("系统预置关系类型不可删除")
     con.execute("UPDATE relation_types SET deleted_at=? WHERE id=? AND deleted_at IS NULL",
                 (_now(), id_))
     con.commit()

--- a/frontend/src/views/OntologyView.vue
+++ b/frontend/src/views/OntologyView.vue
@@ -231,10 +231,10 @@ const etColumns = [
   { title: '名称', key: 'name' },
   { title: '来源', key: 'tenant_id', render: r => h('span', {}, r.tenant_id === 'system' ? '预置' : '自定义') },
   { title: '属性', key: 'attrs', render: r => (r.attrs || []).map(a => a.key).join('、') || '—' },
-  { title: '操作', key: 'op', width: 120, render: r => {
-      if (r.tenant_id === 'system') return h('span', { style: 'color:#aaa' }, '只读')
-      return h('div', {}, [h('n-button', { size: 'tiny', quaternary: true, onClick: () => openTypeModal(r) }, { default: () => '编辑' })])
-    } },
+  { title: '操作', key: 'op', width: 130, render: r => h('div', {}, [
+      h('n-button', { size: 'tiny', quaternary: true, onClick: () => openTypeModal(r) }, { default: () => '编辑' }),
+      h('n-button', { size: 'tiny', quaternary: true, type: 'error', onClick: () => delType(r) }, { default: () => '删除' }),
+    ]) },
 ]
 const rtColumns = [
   { title: '代码', key: 'code' },
@@ -242,10 +242,10 @@ const rtColumns = [
   { title: '方向', key: 'from_type', render: r => h('span', {}, `${entityTypeName(r.from_type)} → ${entityTypeName(r.to_type)}`) },
   { title: '基数', key: 'cardinality' },
   { title: '来源', key: 'tenant_id', render: r => h('span', {}, r.tenant_id === 'system' ? '预置' : '自定义') },
-  { title: '操作', key: 'op', width: 120, render: r => {
-      if (r.tenant_id === 'system') return h('span', { style: 'color:#aaa' }, '只读')
-      return h('n-button', { size: 'tiny', quaternary: true, onClick: () => openRtModal(r) }, { default: () => '编辑' })
-    } },
+  { title: '操作', key: 'op', width: 130, render: r => h('div', {}, [
+      h('n-button', { size: 'tiny', quaternary: true, onClick: () => openRtModal(r) }, { default: () => '编辑' }),
+      h('n-button', { size: 'tiny', quaternary: true, type: 'error', onClick: () => delRt(r) }, { default: () => '删除' }),
+    ]) },
 ]
 const relColumns = [
   { title: '来源', key: 'from', render: r => h('span', {}, `${relName(r.from_id)}` + (relEntityType(r.from_id) ? `（${entityTypeName(relEntityType(r.from_id))}）` : '')) },
@@ -412,6 +412,28 @@ async function saveRt() {
   } catch (e) {
     msg.error(e.response?.data?.detail || '保存失败')
   }
+}
+
+async function delType(t) {
+  const used = entities.value.filter(e => e.entity_type === t.code).length
+  const tip = used
+    ? `仍有 ${used} 个「${t.name}」实体，删除类型不会删除这些实体（其类型将显示为原始代码）。确定删除？`
+    : `确定删除实体类型「${t.name}（${t.code}）」？`
+  if (!confirm(tip)) return
+  await api.delete(`/admin/ontology/entity-types/${t.id}`)
+  msg.success('已删除')
+  reloadAll()
+}
+
+async function delRt(t) {
+  const used = relations.value.filter(r => r.relation_type === t.code).length
+  const tip = used
+    ? `仍有 ${used} 条「${t.name}」关系实例，删除类型不会删除这些关系（其类型将显示为原始代码）。确定删除？`
+    : `确定删除关系类型「${t.name}（${t.code}）」？`
+  if (!confirm(tip)) return
+  await api.delete(`/admin/ontology/relation-types/${t.id}`)
+  msg.success('已删除')
+  reloadAll()
 }
 
 onMounted(reloadAll)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -122,22 +122,25 @@ def test_relation_constraint_validation():
     ontology.delete_relation("default", rid)
 
 
-def test_system_schema_is_readonly():
+def test_system_schema_is_editable():
     ontology.init()
     ontology.seed_schema_if_empty()
     sys_et = ontology.list_schema("default")["entity_types"][0]
     sys_rt = ontology.list_schema("default")["relation_types"][0]
 
-    try:
-        ontology.delete_entity_type("default", sys_et["id"])
-        assert False, "系统预置类型不可删除"
-    except ValueError:
-        pass
-    try:
-        ontology.update_relation_type("default", sys_rt["id"], {"name": "x"})
-        assert False, "系统预置关系类型不可修改"
-    except ValueError:
-        pass
+    # 系统预置类型可编辑（code 不可改，name/属性等可改）
+    ontology.update_entity_type("default", sys_et["id"], {"name": "改名", "description": "d", "icon": "🏷️", "attrs": []})
+    got = [t for t in ontology.list_schema("default")["entity_types"] if t["id"] == sys_et["id"]][0]
+    assert got["name"] == "改名"
+    ontology.update_relation_type("default", sys_rt["id"], {"name": "隶属于2", "description": "d"})
+    got_rt = [t for t in ontology.list_schema("default")["relation_types"] if t["id"] == sys_rt["id"]][0]
+    assert got_rt["name"] == "隶属于2"
+
+    # 系统预置类型可删除
+    ontology.delete_entity_type("default", sys_et["id"])
+    assert not any(t["id"] == sys_et["id"] for t in ontology.list_schema("default")["entity_types"])
+    ontology.delete_relation_type("default", sys_rt["id"])
+    assert not any(t["id"] == sys_rt["id"] for t in ontology.list_schema("default")["relation_types"])
 
     # 租户自定义类型可建可删
     cid = ontology.create_entity_type("default", {"code": "vendor", "name": "供应商", "attrs": []})


### PR DESCRIPTION
## 变更内容

此前 9 个预置实体类型 + 9 个预置关系类型（system 租户）后端硬拦截编辑与删除，用户想给「员工」加工号属性、改「隶属于」显示名都做不到，只能新建冗余类型导致数据分裂。鉴于存量实例均为演示数据（可清库重播种），全面放开：

### 后端
- 移除 `_is_system` 守卫：预置实体/关系类型允许编辑与软删除（code 仍不可改，UPDATE 语句本身不触碰 code）
- `update_relation_type` 的 from_type/to_type/cardinality 改用 COALESCE：部分字段更新时保留原值，修复 NOT NULL 约束报错（也使接口对部分更新健壮）

### 前端
- 类型定义表所有行（含预置）显示「编辑 + 删除」按钮，不再显示"只读"
- 删除前确认弹窗提示存量实例影响（类型删除不级联删实例，实例类型将回退显示原始 code）
- 编辑预置类型时 code 字段禁用（沿用上一 PR 行为）

### 测试
- `test_system_schema_is_readonly` → `test_system_schema_is_editable`：断言预置类型可改名、可软删除
- tests/test_ontology.py 7/7 通过；全量测试中 test_security / test_assignment / test_browser 的失败为预先存在（stash 验证复现），与本改动无关

## 验证
- PYTHONPATH=backend .venv/bin/python -m pytest tests/test_ontology.py -q ✅ 7 passed
- cd frontend && npx vite build ✅