### PR TITLE
fix: 修复本体操作列按钮渲染（手型/间距/颜色）

### DIFF
--- a/frontend/src/views/OntologyView.vue
+++ b/frontend/src/views/OntologyView.vue
@@ -200,7 +200,7 @@
 
 <script setup>
 import { ref, computed, h, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
-import { useMessage } from 'naive-ui'
+import { useMessage, NButton, NTag, NSpace } from 'naive-ui'
 import * as echarts from 'echarts/core'
 import { GraphChart } from 'echarts/charts'
 import { TooltipComponent, LegendComponent } from 'echarts/components'
@@ -231,10 +231,10 @@ const etColumns = [
   { title: '名称', key: 'name' },
   { title: '来源', key: 'tenant_id', render: r => h('span', {}, r.tenant_id === 'system' ? '预置' : '自定义') },
   { title: '属性', key: 'attrs', render: r => (r.attrs || []).map(a => a.key).join('、') || '—' },
-  { title: '操作', key: 'op', width: 130, render: r => h('div', {}, [
-      h('n-button', { size: 'tiny', quaternary: true, onClick: () => openTypeModal(r) }, { default: () => '编辑' }),
-      h('n-button', { size: 'tiny', quaternary: true, type: 'error', onClick: () => delType(r) }, { default: () => '删除' }),
-    ]) },
+  { title: '操作', key: 'op', width: 150, render: r => h(NSpace, { size: 'small' }, { default: () => [
+      h(NButton, { size: 'tiny', quaternary: true, type: 'primary', onClick: () => openTypeModal(r) }, { default: () => '编辑' }),
+      h(NButton, { size: 'tiny', quaternary: true, type: 'error', onClick: () => delType(r) }, { default: () => '删除' }),
+    ] }) },
 ]
 const rtColumns = [
   { title: '代码', key: 'code' },
@@ -242,16 +242,16 @@ const rtColumns = [
   { title: '方向', key: 'from_type', render: r => h('span', {}, `${entityTypeName(r.from_type)} → ${entityTypeName(r.to_type)}`) },
   { title: '基数', key: 'cardinality' },
   { title: '来源', key: 'tenant_id', render: r => h('span', {}, r.tenant_id === 'system' ? '预置' : '自定义') },
-  { title: '操作', key: 'op', width: 130, render: r => h('div', {}, [
-      h('n-button', { size: 'tiny', quaternary: true, onClick: () => openRtModal(r) }, { default: () => '编辑' }),
-      h('n-button', { size: 'tiny', quaternary: true, type: 'error', onClick: () => delRt(r) }, { default: () => '删除' }),
-    ]) },
+  { title: '操作', key: 'op', width: 150, render: r => h(NSpace, { size: 'small' }, { default: () => [
+      h(NButton, { size: 'tiny', quaternary: true, type: 'primary', onClick: () => openRtModal(r) }, { default: () => '编辑' }),
+      h(NButton, { size: 'tiny', quaternary: true, type: 'error', onClick: () => delRt(r) }, { default: () => '删除' }),
+    ] }) },
 ]
 const relColumns = [
   { title: '来源', key: 'from', render: r => h('span', {}, `${relName(r.from_id)}` + (relEntityType(r.from_id) ? `（${entityTypeName(relEntityType(r.from_id))}）` : '')) },
-  { title: '关系', key: 'relation_type', render: r => h('n-tag', { size: 'tiny', round: true, bordered: true, title: r.relation_type }, { default: () => relTypeName(r.relation_type) }) },
+  { title: '关系', key: 'relation_type', render: r => h(NTag, { size: 'tiny', round: true, bordered: true, title: r.relation_type }, { default: () => relTypeName(r.relation_type) }) },
   { title: '目标', key: 'to', render: r => h('span', {}, `${relName(r.to_id)}` + (relEntityType(r.to_id) ? `（${entityTypeName(relEntityType(r.to_id))}）` : '')) },
-  { title: '操作', key: 'op', width: 90, render: r => h('n-button', { size: 'tiny', quaternary: true, type: 'error', onClick: () => delRelation(r.id) }, { default: () => '删除' }) },
+  { title: '操作', key: 'op', width: 90, render: r => h(NButton, { size: 'tiny', quaternary: true, type: 'error', onClick: () => delRelation(r.id) }, { default: () => '删除' }) },
 ]
 const relPagination = { pageSize: 15 }
 


### PR DESCRIPTION
## 变更内容

修复本体页操作列按钮的三个显示问题：

**根因**：render 函数里 `h('n-button', ...)` 的字符串形式不会被 Vue 解析为 naive-ui 组件（组件解析只发生在模板编译阶段），实际渲染成了无样式的原生未知元素——所以没有手型光标、没有按钮样式、间距挤在一起。

**修复**：与项目内 HistoryView/UsersView 的既有惯例一致，改为 `import { NButton, NTag, NSpace } from 'naive-ui'` 后用组件对象渲染：

1. **手型光标**：真正的 NButton 恢复 pointer 样式与 hover 效果
2. **间距**：编辑/删除按钮用 NSpace(size=small) 分隔，不再紧贴
3. **颜色与风格**：编辑 `type=primary`（主题蓝）、删除 `type=error`（红色），与历史会话页操作列风格统一
4. **顺带修复**：业务关系表的关系 tag（此前同为字符串渲染，样式缺失）与该表删除按钮

## 验证
- 前端构建通过（npx vite build）
- 纯前端展示层改动