### PR TITLE
feat: 新增网络运营数字员工小网，本体多跳查询场景打样

### DIFF
--- a/backend/app/catalog/__init__.py
+++ b/backend/app/catalog/__init__.py
@@ -46,6 +46,7 @@ from .seeds import (
     seed_if_empty, backfill_connectors, backfill_subagents_if_empty,
     backfill_ragflow_knowledge_bases,
     backfill_employee_kb_assignments, backfill_ontology_tools,
+    backfill_employees_if_missing,
     seed_assignments_if_empty, seed_admin_if_empty, flag_default_admin_password,
 )
 
@@ -74,5 +75,6 @@ __all__ = [
     "seed_if_empty", "backfill_connectors", "backfill_subagents_if_empty",
     "backfill_ragflow_knowledge_bases",
     "backfill_employee_kb_assignments", "backfill_ontology_tools",
+    "backfill_employees_if_missing",
     "seed_assignments_if_empty", "seed_admin_if_empty", "flag_default_admin_password",
 ]

--- a/backend/app/catalog/seeds.py
+++ b/backend/app/catalog/seeds.py
@@ -46,6 +46,34 @@ def _tools_with_ontology(tools: list[str]) -> list[str]:
     return tools + list(ONTOLOGY_TOOLS)
 
 
+# 内置员工种子配置（seed_if_empty 全量播种 / backfill_employees_if_missing 幂等补缺共用）
+EMPLOYEE_SEEDS = {
+    "xiaosu": dict(
+        skills=["product-faq", "complaint-handling"],
+        tools=_tools_with_ontology(["kb_search", "create_ticket", "start_refund"]),
+        kbs=[], sops=["sop_refund", "sop_complaint"], cons=["crm"]),
+    "xiaoshu": dict(
+        skills=["data-analysis"], tools=_tools_with_ontology([]), kbs=[], sops=[]),
+    "xiaoxiao": dict(
+        skills=["enterprise-sales"],
+        tools=_tools_with_ontology(["kb_search", "bocha_search"]),
+        kbs=[]),
+    "hrbp": dict(
+        skills=["hr-assistant"],
+        tools=_tools_with_ontology(["kb_search", "create_ticket", "bocha_search"]),
+        kbs=[]),
+    "biz-analyzer": dict(
+        skills=["business-overview", "root-cause-analysis",
+                "decision-analysis", "market-intelligence"],
+        tools=_tools_with_ontology(["run_python", "bocha_search", "get_current_time"]),
+        kbs=[], sops=[], cons=[]),
+    "net-ops": dict(
+        skills=["fault-impact-analysis"],
+        tools=_tools_with_ontology(["kb_search", "create_ticket", "get_current_time"]),
+        kbs=[], sops=[], cons=[]),
+}
+
+
 def seed_if_empty():
     """把现有员工 + 目录种子进库（仅当 employees 为空时）。"""
     con = _conn()
@@ -140,29 +168,7 @@ def seed_if_empty():
             (cid, cname, cdesc, json.dumps(ccfg, ensure_ascii=False)))
 
     # --- employees ---
-    seeds = {
-        "xiaosu": dict(
-            skills=["product-faq", "complaint-handling"],
-            tools=_tools_with_ontology(["kb_search", "create_ticket", "start_refund"]),
-            kbs=[],
-            sops=["sop_refund", "sop_complaint"], cons=["crm"]),
-        "xiaoshu": dict(
-            skills=["data-analysis"], tools=_tools_with_ontology([]), kbs=[], sops=[]),
-        "xiaoxiao": dict(
-            skills=["enterprise-sales"],
-            tools=_tools_with_ontology(["kb_search", "bocha_search"]),
-            kbs=[]),
-        "hrbp": dict(
-            skills=["hr-assistant"],
-            tools=_tools_with_ontology(["kb_search", "create_ticket", "bocha_search"]),
-            kbs=[]),
-        "biz-analyzer": dict(
-            skills=["business-overview", "root-cause-analysis",
-                    "decision-analysis", "market-intelligence"],
-            tools=_tools_with_ontology(["run_python", "bocha_search", "get_current_time"]),
-            kbs=[], sops=[], cons=[]),
-    }
-    for emp_id, sel in seeds.items():
+    for emp_id, sel in EMPLOYEE_SEEDS.items():
         spec = load_spec(str(ROOT / "employees" / f"{emp_id}.yaml"))
         model = re.sub(r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), m.group(0)),
                        spec.model)
@@ -229,13 +235,72 @@ def backfill_ontology_tools():
             "INSERT OR IGNORE INTO tools(id,name,description,source,needs_approval) "
             "VALUES(?,?,?,?,?)",
             (tid, name, desc, "local", None))
-    for e in ("xiaosu", "xiaoshu", "xiaoxiao", "hrbp", "biz-analyzer"):
+    for e in ("xiaosu", "xiaoshu", "xiaoxiao", "hrbp", "biz-analyzer", "net-ops"):
         if cur.execute("SELECT 1 FROM employees WHERE id=? AND deleted_at IS NULL",
                        (e,)).fetchone():
             for t in ONTOLOGY_TOOLS:
                 cur.execute("INSERT OR IGNORE INTO employee_tools VALUES(?,?)", (e, t))
     con.commit()
     con.close()
+
+
+def backfill_employees_if_missing():
+    """幂等补齐内置种子员工：新库由 seed_if_empty 全量写入；老库升级新增的
+    员工（如 net-ops）靠这里补种。已存在（含软删除）的员工不覆盖，
+    尊重管理员在资源中心的改动与删除。"""
+    con = _conn()
+    cur = con.cursor()
+    now = time.strftime("%Y-%m-%d %H:%M:%S")
+
+    # 老库可能缺新技能目录（如 fault-impact-analysis），扫描 skills/ 补登记
+    for sd in sorted((ROOT / "skills").glob("*/")):
+        cur.execute(
+            "INSERT OR IGNORE INTO skills(id,name,description,dir) VALUES(?,?,?,?)",
+            (sd.name, sd.name, _skill_desc(sd), f"skills/{sd.name}"))
+
+    added = []
+    for emp_id, sel in EMPLOYEE_SEEDS.items():
+        if cur.execute("SELECT 1 FROM employees WHERE id=?", (emp_id,)).fetchone():
+            continue  # 已存在（含软删除）：不覆盖
+        yaml_path = ROOT / "employees" / f"{emp_id}.yaml"
+        if not yaml_path.exists():
+            continue
+        spec = load_spec(str(yaml_path))
+        model = re.sub(r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), m.group(0)),
+                       spec.model)
+        cur.execute(
+            "INSERT INTO employees(id,name,role,model,persona,backend,mcp_servers,"
+            "interrupt_on,subagents,subagent_policy,created_at,updated_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+            (emp_id, spec.name, spec.role, model, spec.persona, spec.backend,
+             json.dumps(spec.mcp_servers, ensure_ascii=False),
+             json.dumps(spec.interrupt_on, ensure_ascii=False),
+             json.dumps(spec.subagents, ensure_ascii=False),
+             spec.subagent_policy, now, now))
+        for s in sel.get("skills", []):
+            cur.execute("INSERT OR IGNORE INTO employee_skills VALUES(?,?)", (emp_id, s))
+        for t in sel.get("tools", []):
+            cur.execute("INSERT OR IGNORE INTO employee_tools VALUES(?,?)", (emp_id, t))
+        for k in sel.get("kbs", []):
+            cur.execute("INSERT OR IGNORE INTO employee_kbs VALUES(?,?)", (emp_id, k))
+        for s in sel.get("sops", []):
+            cur.execute("INSERT OR IGNORE INTO employee_sops VALUES(?,?)", (emp_id, s))
+        for c in sel.get("cons", []):
+            cur.execute("INSERT OR IGNORE INTO employee_connectors VALUES(?,?)", (emp_id, c))
+        added.append(emp_id)
+
+    # 新补种的员工授予所有现有用户（管理员之后可在用户管理里回收）
+    if added:
+        for u in list_users():
+            for emp_id in added:
+                cur.execute(
+                    "INSERT OR IGNORE INTO user_employee_assignments"
+                    "(user_id,employee_id,granted_by,overrides,created_at) VALUES(?,?,?,?,?)",
+                    (u["id"], emp_id, "u_admin", "{}", now))
+    con.commit()
+    con.close()
+    if added:
+        print(f"[seed] 已为老库补种内置员工：{', '.join(added)}")
 
 
 def backfill_ragflow_knowledge_bases():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,12 +52,15 @@ async def lifespan(app):
     catalog.backfill_employee_kb_assignments()
     catalog.backfill_subagents_if_empty()
     catalog.backfill_ontology_tools()
+    catalog.backfill_employees_if_missing()
     catalog.seed_admin_if_empty()
     catalog.flag_default_admin_password()
     catalog.seed_assignments_if_empty()
     ontology.init()
     ontology.seed_schema_if_empty()
+    ontology.backfill_schema_types()
     ontology.seed_demo_if_empty()
+    ontology.seed_netops_demo_if_empty()
     conversations.ensure_default_channel(
         [e["id"] for e in runtime.discover_employees()]
     )

--- a/backend/app/ontology.py
+++ b/backend/app/ontology.py
@@ -139,6 +139,17 @@ SCHEMA_ENTITY_TYPES = [
         {"key": "date", "name": "下单日期", "type": "text"},
         {"key": "detail", "name": "明细", "type": "textarea"},
     ]),
+    ("station", "基站", "网络运营的基站/接入网点", "📡", [
+        {"key": "code", "name": "基站编号", "type": "text"},
+        {"key": "address", "name": "站址", "type": "text"},
+        {"key": "status", "name": "运行状态", "type": "text"},
+        {"key": "tech", "name": "制式", "type": "text"},
+    ]),
+    ("area", "片区", "基站覆盖的业务片区", "🗺️", [
+        {"key": "households", "name": "覆盖户数", "type": "text"},
+        {"key": "priority", "name": "保障等级", "type": "text"},
+        {"key": "intro", "name": "简介", "type": "textarea"},
+    ]),
 ]
 
 # 模式层预置：9 个关系类型（system 租户，全局共享）
@@ -152,6 +163,9 @@ SCHEMA_RELATION_TYPES = [
     ("correspond_to", "对应", "project", "contract", "1:1", "项目对应某合同"),
     ("place_order", "下单", "customer", "order", "1:n", "客户下达订单"),
     ("include", "包含", "order", "product", "1:n", "订单包含产品"),
+    ("cover", "覆盖", "station", "area", "1:n", "基站覆盖某片区"),
+    ("maintain", "维护", "employee", "station", "n:n", "装维人员维护某基站"),
+    ("located_in", "居住于", "customer", "area", "n:1", "客户位于某片区"),
 ]
 
 # 数据层演示种子：虚拟企业「星云科技」（default 租户）
@@ -237,6 +251,26 @@ def seed_schema_if_empty():
     con.commit()
     con.close()
     print(f"[ontology] 已播种模式层：{len(SCHEMA_ENTITY_TYPES)} 实体类型 / {len(SCHEMA_RELATION_TYPES)} 关系类型")
+
+
+def backfill_schema_types():
+    """幂等补齐预置模式层类型（新库由 seed_schema_if_empty 写入；
+    老库新增类型靠这里 INSERT OR IGNORE 补缺，不覆盖管理员自定义）。"""
+    con = _conn()
+    cur = con.cursor()
+    now = _now()
+    for code, name, desc, icon, attrs in SCHEMA_ENTITY_TYPES:
+        cur.execute(
+            "INSERT OR IGNORE INTO entity_types(code,name,description,icon,attrs,tenant_id,created_at,updated_at)"
+            " VALUES(?,?,?,?,?,?,?,?)",
+            (code, name, desc, icon, json.dumps(attrs, ensure_ascii=False), "system", now, now))
+    for code, name, frm, to, card, desc in SCHEMA_RELATION_TYPES:
+        cur.execute(
+            "INSERT OR IGNORE INTO relation_types(code,name,from_type,to_type,cardinality,description,tenant_id,created_at,updated_at)"
+            " VALUES(?,?,?,?,?,?,?,?,?)",
+            (code, name, frm, to, card, desc, "system", now, now))
+    con.commit()
+    con.close()
 
 
 def seed_demo_if_empty():
@@ -326,6 +360,114 @@ def seed_demo_if_empty():
     con.commit()
     con.close()
     print("[ontology] 已播种演示数据：星云科技（5 部门 / 6 员工 / 4 客户 / 3 项目 / 3 合同 / 4 订单）")
+
+
+# 数据层演示种子：网络运营场景「星联通信」（default 租户，与星云科技并存）
+_NETOPS_EMPLOYEES = [
+    ("李建国", {"title": "网络监控值班长", "phone": "13800001001", "status": "在职"}),
+    ("王强", {"title": "装维工程师", "phone": "13800001002", "status": "在职"}),
+    ("赵敏", {"title": "装维工程师", "phone": "13800001003", "status": "在职"}),
+    ("陈涛", {"title": "装维工程师", "phone": "13800001004", "status": "在职"}),
+]
+_NETOPS_AREAS = [
+    ("城东片区", {"households": "1.2 万", "priority": "普通", "intro": "老城区以东，住宅为主"}),
+    ("高新区片区", {"households": "0.8 万", "priority": "重点保障", "intro": "高新技术企业园区，含政企客户"}),
+    ("老城片区", {"households": "0.6 万", "priority": "普通", "intro": "老城核心商圈"}),
+]
+_NETOPS_STATIONS = [
+    ("城东1号基站", {"code": "BS-001", "address": "城东街道88号", "status": "正常", "tech": "5G"}),
+    ("城东2号基站", {"code": "BS-002", "address": "城东路与纬三路交叉口", "status": "正常", "tech": "5G"}),
+    ("高新区1号基站", {"code": "BS-003", "address": "高新大道1号园区北门", "status": "退服", "tech": "5G"}),
+    ("老城1号基站", {"code": "BS-004", "address": "老城中路12号", "status": "升级中", "tech": "4G→5G"}),
+]
+_NETOPS_CUSTOMERS = [
+    ("张桂芳", {"grade": "VIP", "contact": "13911112222", "industry": "个人",
+                "intro": "城东片区个人VIP客户"}),
+    ("刘志远", {"grade": "普通", "contact": "13933334444", "industry": "个人",
+                "intro": "城东片区个人客户"}),
+    ("杭州智造科技", {"grade": "VIP", "contact": "0571-88990000", "industry": "智能制造",
+                       "intro": "高新区政企VIP客户，专线+组网业务"}),
+    ("王秀英", {"grade": "普通", "contact": "13955556666", "industry": "个人",
+                "intro": "高新区个人客户"}),
+    ("周明轩", {"grade": "VIP", "contact": "13977778888", "industry": "个人",
+                "intro": "老城片区个人VIP客户"}),
+]
+
+
+def seed_netops_demo_if_empty():
+    """网络运营演示种子：default 租户无基站实体时播种（幂等）。
+
+    场景主线：基站退服 → 覆盖片区 → 受影响客户（筛VIP）→ 装维负责人，
+    用于展示本体的多跳关系查询能力。
+    """
+    con = _conn()
+    has_station = con.execute(
+        "SELECT 1 FROM entities WHERE entity_type='station' AND tenant_id='default' AND deleted_at IS NULL"
+    ).fetchone()
+    if has_station:
+        con.close()
+        return
+    now = _now()
+    ids: dict[tuple, int] = {}
+
+    def add(type_, name, props):
+        ids[(type_, name)] = dblayer.insert_returning_id(
+            con,
+            "INSERT INTO entities(entity_type,name,props,tenant_id,created_at,updated_at)"
+            " VALUES(?,?,?,?,?,?)",
+            (type_, name, json.dumps(props, ensure_ascii=False), "default", now, now))
+
+    def link(frm, to, rel):
+        con.execute(
+            "INSERT INTO relations(from_id,to_id,relation_type,props,tenant_id,created_at,updated_at)"
+            " VALUES(?,?,?,'{}',?,?,?)",
+            (frm, to, rel, "default", now, now))
+
+    add("org", "星联通信", {
+        "industry": "通信运营", "scale": "1000+ 人",
+        "address": "杭州市滨江区",
+        "intro": "演示用虚拟运营商，用于网络运营场景（基站/片区/装维/客户保障）展示。"})
+    add("department", "网络运营部", {"function": "网络运营与维护", "head": "李建国",
+                                    "intro": "负责基站运维、装维调度与客户网络保障"})
+    link(ids[("org", "星联通信")], ids[("department", "网络运营部")], "belong_to")
+
+    for name, props in _NETOPS_EMPLOYEES:
+        add("employee", name, props)
+        link(ids[("employee", name)], ids[("department", "网络运营部")], "belongs_to")
+    link(ids[("employee", "李建国")], ids[("department", "网络运营部")], "manage")
+
+    for name, props in _NETOPS_AREAS:
+        add("area", name, props)
+    for name, props in _NETOPS_STATIONS:
+        add("station", name, props)
+    for name, props in _NETOPS_CUSTOMERS:
+        add("customer", name, props)
+
+    # 基站-片区（覆盖）
+    for station, area in [
+        ("城东1号基站", "城东片区"), ("城东2号基站", "城东片区"),
+        ("高新区1号基站", "高新区片区"), ("老城1号基站", "老城片区"),
+    ]:
+        link(ids[("station", station)], ids[("area", area)], "cover")
+
+    # 装维人员-基站（维护）
+    for emp, station in [
+        ("王强", "城东1号基站"), ("王强", "城东2号基站"),
+        ("赵敏", "高新区1号基站"), ("陈涛", "老城1号基站"),
+    ]:
+        link(ids[("employee", emp)], ids[("station", station)], "maintain")
+
+    # 客户-片区（居住于）
+    for customer, area in [
+        ("张桂芳", "城东片区"), ("刘志远", "城东片区"),
+        ("杭州智造科技", "高新区片区"), ("王秀英", "高新区片区"),
+        ("周明轩", "老城片区"),
+    ]:
+        link(ids[("customer", customer)], ids[("area", area)], "located_in")
+
+    con.commit()
+    con.close()
+    print("[ontology] 已播种网络运营演示数据：星联通信（4 员工 / 4 基站 / 3 片区 / 5 客户）")
 
 
 # ---------------- Schema CRUD ----------------

--- a/backend/app/tools/ontology_tools.py
+++ b/backend/app/tools/ontology_tools.py
@@ -33,9 +33,11 @@ def make_ontology_tools(user_id: str | None) -> list:
         """【企业业务本体查询】按实体类型和/或关键词查找业务实体。
 
         实体类型：org(组织)/department(部门)/position(岗位)/employee(员工)/
-        customer(客户)/product(产品)/project(项目)/contract(合同)/order(订单)。
-        涉及公司内部的人、部门、客户、项目、合同、订单、产品信息时，先调用本工具
-        拿到实体 id，再配合 ontology_query_relations 展开其关联关系。
+        customer(客户)/product(产品)/project(项目)/contract(合同)/order(订单)/
+        station(基站)/area(片区)。
+        涉及公司内部的人、部门、客户、项目、合同、订单、产品信息，或网络运营的
+        基站、片区信息时，先调用本工具拿到实体 id，再配合 ontology_query_relations
+        展开其关联关系。
         """
         items = ontology.find_entities(
             tenant,
@@ -51,9 +53,12 @@ def make_ontology_tools(user_id: str | None) -> list:
 
         关系类型：belong_to(隶属于)/belongs_to(属于)/hold_position(担任)/
         manage(负责)/follow_up(跟进)/serve(服务)/correspond_to(对应)/
-        place_order(下单)/include(包含)。direction: any/out/in。
-        查询"某人负责哪些项目、跟进哪些客户、某客户下过哪些订单"等时使用。
-        通常先 ontology_find_entities 拿到实体 id 再调用本工具。
+        place_order(下单)/include(包含)/cover(基站覆盖片区)/
+        maintain(员工维护基站)/located_in(客户位于片区)。direction: any/out/in。
+        查询"某人负责哪些项目、跟进哪些客户、某客户下过哪些订单、
+        某基站覆盖哪些片区、片区里有哪些客户、谁维护某基站"等时使用，
+        可连续多跳（如基站→片区→客户）。通常先 ontology_find_entities
+        拿到实体 id 再调用本工具。
         """
         rows = ontology.query_relations(
             tenant,

--- a/backend/employees/net-ops.yaml
+++ b/backend/employees/net-ops.yaml
@@ -1,0 +1,41 @@
+id: net-ops
+name: 小网
+role: 网络运营专家
+model: ${MODEL_NAME}
+persona: |
+  你是小网，星联通信的网络运营专家，负责基站运维、装维调度与客户网络保障。
+  语气干练，结论先行，处置建议可执行。
+
+  你掌握的企业业务本体（结构化业务地图，权威数据源）：
+  - 实体：org(组织)/department(部门)/employee(员工)/customer(客户)/
+    station(基站)/area(片区) 等
+  - 关系：belong_to(隶属于)/manage(负责)/cover(基站覆盖片区)/
+    maintain(员工维护基站)/located_in(客户位于片区) 等
+
+  ## 工具路由（最重要，严格遵守）
+  1. 凡涉及"哪个基站、哪个片区、谁负责、谁维护、影响哪些客户、客户等级"
+     等实体关系问题，必须走 ontology_find_entities + ontology_query_relations
+     沿关系链查询，禁止凭记忆或 kb_search 猜测人员名单、基站状态、客户归属。
+     多跳查询逐跳展开：基站 → cover → 片区 → located_in(入边) → 客户，
+     基站 → maintain(入边) → 装维人员。
+  2. 回答结论必须基于工具返回的真实数据，并标注来源：
+     "以上来自企业本体查询（N 个实体 / M 条关系）"。
+  3. 网络运营规章制度类问题（SLA 标准、报装流程、资费说明）走 kb_search。
+  4. 客户报障 / 需要派单处理时，按 /skills/fault-impact-analysis/SKILL.md
+     规程执行，必要时用 create_ticket 登记工单。
+  5. 你是只读视角：不承诺改动网络配置，处置建议交给装维人员执行。
+
+  ## 回答格式
+  故障类问题按「影响面 → 责任人 → 处置建议 → 已登记工单」输出；
+  查询类问题先给结论清单，再附数据来源。
+
+skills:
+  - fault-impact-analysis
+tools:
+  - kb_search
+  - create_ticket
+  - get_current_time
+mcp_servers: {}
+interrupt_on:
+  create_ticket: false
+  kb_search: false

--- a/backend/skills/fault-impact-analysis/SKILL.md
+++ b/backend/skills/fault-impact-analysis/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: fault-impact-analysis
+description: 故障影响分析技能。当用户报告基站故障、网络中断、退服、大面积断网，或需要评估故障影响范围、安排装维人员时使用。
+---
+
+# 故障影响分析
+
+你是网络运营值班专家，接到故障报告或影响评估请求时严格按以下规程执行。
+所有事实必须来自企业本体查询（ontology_find_entities / ontology_query_relations），
+禁止凭经验编造客户名单、负责人或基站状态。
+
+## 执行步骤
+
+### 步骤1：定位故障实体
+
+用 ontology_find_entities 找到涉事基站（entity_type=station，keyword=基站名或编号）。
+确认其 props 中的 status（正常/退服/升级中）。用户只报了片区或客户名时，反向定位：
+先查片区/客户，再沿关系找到关联基站。
+
+### 步骤2：展开影响面（逐跳查询）
+
+从基站实体 id 出发：
+1. ontology_query_relations(entity_id, relation_type="cover") → 得到覆盖片区；
+2. 对每个片区，ontology_query_relations(片区id, relation_type="located_in", direction="in")
+   → 得到受影响客户清单；
+3. 汇总客户 grade 属性，单独标出 VIP 客户（优先保障）。
+
+### 步骤3：定位责任人
+
+- 装维：ontology_query_relations(基站id, relation_type="maintain", direction="in")
+  → 负责该基站的装维工程师（含电话）；
+- 升级：若影响 VIP 或政企客户，同时查片区维护部门值班负责人
+  （部门 → manage/belongs_to 关系）。
+
+### 步骤4：输出处置建议并登记工单
+
+按「影响面 → 责任人 → 处置建议」结构输出：
+- 影响面：退服基站 / 覆盖片区 / 受影响客户数 / VIP 客户清单
+- 责任人：装维工程师姓名与电话
+- 处置建议：按客户等级排序（VIP 优先）、给出临时缓解措施（如切换相邻基站）
+- 用户确认需要派单时，调用 create_ticket 登记故障工单
+
+结尾标注数据来源：「以上来自企业本体查询（N 个实体 / M 条关系）」。
+
+## 注意事项
+
+- 基站升级中 ≠ 故障，回答前先看 status 属性再定性
+- 查不到关系时如实说明"本体中未登记"，不要编造
+- 涉及资费赔偿承诺前，先走 kb_search 查现行 SLA 制度

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -44,6 +44,33 @@ def test_employee_crud_and_interrupt_derivation():
     assert catalog.get_employee_config(eid) is None
 
 
+def test_backfill_employees_if_missing_adds_netops():
+    """老库补种：net-ops 员工缺失时由 backfill 补回（含技能/工具/本体工具）。"""
+    catalog.init()
+    catalog.seed_if_empty()  # 新库播种已含 net-ops
+    assert catalog.get_employee_config("net-ops")["name"] == "小网"
+    assert "fault-impact-analysis" in catalog.get_employee_config("net-ops")["skills"]
+
+    # 模拟老库（无 net-ops）：硬删相关行后 backfill 应补回
+    con = sqlite3.connect(str(catalog.db.DB))
+    for tbl in ("employee_skills", "employee_tools", "employee_kbs",
+                "employee_sops", "employee_connectors"):
+        con.execute(f"DELETE FROM {tbl} WHERE employee_id='net-ops'")
+    con.execute("DELETE FROM user_employee_assignments WHERE employee_id='net-ops'")
+    con.execute("DELETE FROM employees WHERE id='net-ops'")
+    con.commit()
+    con.close()
+    assert catalog.get_employee_config("net-ops") is None
+
+    catalog.backfill_employees_if_missing()
+    cfg = catalog.get_employee_config("net-ops")
+    assert cfg is not None and cfg["name"] == "小网"
+    assert "ontology_find_entities" in cfg["tools"]
+    assert "fault-impact-analysis" in cfg["skills"]
+    # 幂等：再跑一次不重复
+    catalog.backfill_employees_if_missing()
+
+
 # ---- 知识库（RAGFlow 映射） ----
 
 def test_kb_crud_only_tracks_ragflow_dataset_mapping():

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -11,10 +11,11 @@ def test_seed_schema_and_demo_are_idempotent():
     ontology.seed_demo_if_empty()
 
     schema = ontology.list_schema("default")
-    assert len(schema["entity_types"]) == 9
-    assert len(schema["relation_types"]) == 9
+    assert len(schema["entity_types"]) == 11
+    assert len(schema["relation_types"]) == 12
     codes = {t["code"] for t in schema["entity_types"]}
-    assert {"org", "employee", "customer", "project", "contract", "order"} <= codes
+    assert {"org", "employee", "customer", "project", "contract", "order",
+            "station", "area"} <= codes
 
     stats = ontology.stats("default")
     assert stats["total_entities"] == 35
@@ -56,7 +57,7 @@ def test_tenant_isolation():
     assert ontology.stats("tenant-b")["total_entities"] == 0
     # system 预置 schema 对任何租户可见
     schema = ontology.list_schema("tenant-b")
-    assert len(schema["entity_types"]) == 9
+    assert len(schema["entity_types"]) == 11
 
 
 def test_entity_and_relation_crud():
@@ -166,3 +167,49 @@ def test_make_ontology_tools_bind_tenant():
     rels = _json.loads(tools["ontology_query_relations"].invoke(
         {"entity_id": out[0]["id"], "relation_type": "manage"}))
     assert rels[0]["target"]["name"] == "华芯智慧工厂"
+
+
+def test_netops_demo_seed_and_multihop_chain():
+    """网络运营演示种子 + 故障影响分析多跳链：基站→片区→客户 / 基站→装维。"""
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    ontology.seed_netops_demo_if_empty()
+    # 幂等
+    ontology.seed_netops_demo_if_empty()
+
+    # 老库补新 schema 类型（station/area 实体类型已随 seed 播种，这里验证幂等）
+    ontology.backfill_schema_types()
+    schema = ontology.list_schema("default")
+    codes = {t["code"] for t in schema["entity_types"]}
+    assert {"station", "area"} <= codes
+    rcodes = {t["code"] for t in schema["relation_types"]}
+    assert {"cover", "maintain", "located_in"} <= rcodes
+
+    # 多跳链1：退服基站 BS-003 → 高新区片区 → 受影响客户（VIP：杭州智造科技）
+    st = ontology.find_entities("default", entity_type="station", keyword="BS-003")
+    assert len(st) == 1 and st[0]["status"] == "退服"
+    areas = ontology.query_relations("default", st[0]["id"], relation_type="cover")
+    assert [a["target"]["name"] for a in areas] == ["高新区片区"]
+    customers = ontology.query_relations(
+        "default", areas[0]["target"]["id"], relation_type="located_in", direction="in")
+    names = {c["target"]["name"] for c in customers}
+    assert names == {"杭州智造科技", "王秀英"}
+    vip = [c["target"] for c in customers if c["target"].get("grade") == "VIP"]
+    assert [v["name"] for v in vip] == ["杭州智造科技"]
+
+    # 多跳链2：基站 → 装维负责人（maintain 入边）
+    maintainers = ontology.query_relations(
+        "default", st[0]["id"], relation_type="maintain", direction="in")
+    assert [m["target"]["name"] for m in maintainers] == ["赵敏"]
+    assert maintainers[0]["target"]["phone"] == "13800001003"
+
+
+def test_netops_demo_seed_skips_when_station_exists():
+    """已有基站实体的库不重复播种（保护管理员手工录入的网络数据）。"""
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    ontology.create_entity("default", {"entity_type": "station", "name": "既有基站",
+                                        "props": {"code": "BS-999"}})
+    ontology.seed_netops_demo_if_empty()
+    assert ontology.find_entities("default", entity_type="customer", keyword="星联") == []
+    assert ontology.find_entities("default", entity_type="org", keyword="星联") == []

--- a/tests/test_p0_fixes.py
+++ b/tests/test_p0_fixes.py
@@ -44,7 +44,7 @@ def test_seed_admin_creates_when_empty(monkeypatch):
 def test_seed_if_empty_works_with_soft_delete_migration():
     """迁移后的表含 deleted_at，种子 INSERT 必须显式列名（容器首次启动会走这里）。"""
     catalog.seed_if_empty()
-    assert len(catalog.list_employees_meta()) == 5
+    assert len(catalog.list_employees_meta()) == 6
     assert catalog.get_skill("product-faq") is not None
 
 


### PR DESCRIPTION
## 变更内容

用网络运营的日常场景（基站退服故障处置）打样企业本体的核心价值——多跳关系查询，这是知识库检索做不到的能力。

### 本体扩展
- 新增实体类型：station(基站)📡 / area(片区)🗺️；关系类型：cover(覆盖)、maintain(维护)、located_in(居住于)
- `backfill_schema_types()`：老库幂等补齐新增预置类型（新库由 seed_schema_if_empty 播种）
- `seed_netops_demo_if_empty()`：网络运营演示数据「星联通信」（1 组织 / 4 员工 / 4 基站 / 3 片区 / 5 客户），含退服基站 BS-003、VIP 客户分层、装维人员电话等场景要素

### 新员工：小网（net-ops，网络运营专家）
- 人设强制本体优先路由：实体关系问题必须走 ontology 工具，禁止 kb_search 猜测；结论标注数据来源
- 新技能 fault-impact-analysis（故障影响分析规程）：定位基站 → cover 展开片区 → located_in 入边查受影响客户 → 筛 VIP → maintain 入边找装维责任人 → 登记工单
- seeds dict 提取为模块级 EMPLOYEE_SEEDS，新增 `backfill_employees_if_missing()`：老库幂等补种新员工（含技能/工具/授权），后续新增内置员工也可复用

### 端到端验证（真实服务 + PG）
问「BS-003 基站退服，影响哪些 VIP 客户、派谁去修」：模型调用 2 次 find_entities + 10 次 query_relations 完成多跳链，正确输出「高新区片区 / 受影响 2 户（VIP：杭州智造科技）/ 装维赵敏 13800001003 / 工单 T0827160505 urgent」，并如实说明"本体中未登记"的关系（未编造）。

## 验证
- tests/test_ontology.py + test_catalog.py + test_p0_fixes.py 全过（含新增多跳链/backfill/幂等测试）
- 全量测试中 test_isolation / test_browser_* / test_no_empty_conv / test_security / test_assignment 为预先存在的环境性失败（stash 验证复现）
- 真实服务重启日志确认补种：`[seed] 已为老库补种内置员工：net-ops` + `[ontology] 已播种网络运营演示数据`