### PR TITLE
docs: 中文 README 移除英文段落，双语同步 net-ops 员工

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@ Through its five-layer capability model — **Employee → Workflow/SOP → Skil
 
 ## Highlights
 
-- 🧑‍💼 **Digital Employee Building & Management** — Persona, model, skills, tools, knowledge bases, SOPs, and connectors are all configured through a web UI; the runtime reads everything from a catalog database. Five example employees ship out of the box (customer service / data analyst / sales advisor / HR / business analyst), with soft-delete and restore.
+- 🧑‍💼 **Digital Employee Building & Management** — Persona, model, skills, tools, knowledge bases, SOPs, and connectors are all configured through a web UI; the runtime reads everything from a catalog database. Six example employees ship out of the box (customer service / data analyst / sales advisor / HR / business analyst / network ops), with soft-delete and restore.
 - 🧩 **Process Skills & SOPs** — Skills are captured as `SKILL.md` playbooks (with trigger conditions and execution steps), seeded into the Store for the model to consult on demand — no more skipping steps from memory. Critical business flows can be hardened as StateGraph state machines (with human approval nodes) to guarantee multi-step accuracy.
 - 📚 **Enterprise Knowledge Ontology** — Knowledge is organized as structured assets with business semantics (topics, rules, playbooks, sources); digital employees answer from real material with cited sources. FAQ, markdown product wiki, and RAGFlow vector retrieval are already integrated.
 - 🔌 **Connector & Tool Ecosystem** — Connect external systems such as CRM and news via the MCP standard (stdio and npx). Built-in atomic tools for tickets, search, document generation, and data analysis make business-system extension easy.
@@ -186,6 +186,7 @@ The current release ships with a product FAQ knowledge base, markdown product wi
 | `xiaoxiao` | Sales advisor | Enterprise sales, solution doc generation | CRM |
 | `hrbp` | HR partner | HR assistant | CRM |
 | `biz-analyzer` | Business analysis & decision advisor | Business overview, root-cause analysis, decision analysis, market intelligence | — |
+| `net-ops` | Network operations expert | Fault impact analysis (base-station outage scenario showcasing multi-hop ontology queries) | — |
 
 > Built-in skills live in `backend/skills/` (each with a `SKILL.md` playbook). The `frontend-design` skill is based on [Matt Pocock](https://github.com/mattpocock)'s open-source skill library and distributed under [Apache License 2.0](backend/skills/frontend-design/LICENSE.txt), with the original license attached therein.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 中文 | **[English](README.en.md)**
 
-UniEmployee is an enterprise platform for building and running AI digital employees — turn staff experience, business processes, and judgment into always-on, configurable, approval-gated, and fully observable AI employees.
-
 [![CI](https://github.com/zj-unicom-ai/UniEmployee/actions/workflows/ci.yml/badge.svg)](https://github.com/zj-unicom-ai/UniEmployee/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](backend/pyproject.toml)
@@ -15,7 +13,7 @@ UniEmployee 是一套面向企业的**数字员工构建与运行平台**：把�
 
 ## 核心亮点
 
-- 🧑‍💼 **数字员工构建与管理**：人设、模型、技能、工具、知识库、SOP、连接器全部页面化配置，运行时以目录库为准；内置 5 个示例员工（客服 / 数据分析 / 销售顾问 / HR / 经营分析），支持软删除与恢复。
+- 🧑‍💼 **数字员工构建与管理**：人设、模型、技能、工具、知识库、SOP、连接器全部页面化配置，运行时以目录库为准；内置 6 个示例员工（客服 / 数据分析 / 销售顾问 / HR / 经营分析 / 网络运营），支持软删除与恢复。
 - 🧩 **流程型技能与 SOP**：技能以 `SKILL.md` 规程沉淀（含触发条件与执行步骤），播种进 Store 供模型按需查阅，不凭记忆跳过；关键业务流程可用 StateGraph 状态机固化（含人工审批节点），保证多步流程准确执行。
 - 📚 **企业知识本体**：知识按主题、规则、规程与来源组织为带业务语义的结构化资产，数字员工基于真实资料作答并标注来源；已接入 FAQ、产品 Wiki 与 RAGFlow 多源知识，概念类型化与检索调试持续建设中。
 - 🔌 **连接器与工具生态**：通过 MCP 标准接入 CRM、新闻等外部系统（stdio 与 npx 两种形态），内置工单、搜索、文档生成、数据分析等原子工具，业务系统可轻松扩展。
@@ -205,6 +203,7 @@ Employee ── 数字员工（人设 / 模型 / 技能 / 工具 / 知识库 / �
 | `xiaoxiao` | 销售顾问 | 企业销售、方案文档生成 | CRM |
 | `hrbp` | HR 合作伙伴 | HR 助手 | CRM |
 | `biz-analyzer` | 经营分析与决策顾问 | 经营全景、归因分析、决策分析、市场情报 | — |
+| `net-ops` | 网络运营专家 | 故障影响分析（基站退服场景打样本体多跳查询） | — |
 
 > 内置技能存于 `backend/skills/`（各含 `SKILL.md` 规程）。其中 `frontend-design` 技能基于 [Matt Pocock](https://github.com/mattpocock) 的开源技能库编写，按 [Apache License 2.0](backend/skills/frontend-design/LICENSE.txt) 分发，其内独立附带原始许可证。
 


### PR DESCRIPTION
## 变更内容
1. 删除中文 README 开头的英文简介段（与中文语境不协调，英文内容已在 README.en.md）
2. 双语 README 同步上一 PR 的 net-ops 员工：内置员工表 + 亮点里 5→6 个示例员工

## 验证
- 纯文档改动，无代码影响