### PR TITLE
feat: MCP 连接器支持 HTTP transport（Streamable HTTP）

### DIFF
--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -230,13 +230,19 @@ async def _assemble_tools(spec: EmployeeSpec, checkpointer=None,
         servers = {}
         for name, cfg in spec.mcp_servers.items():
             cfg = dict(cfg)
-            if cfg.get("transport") == "stdio":
+            transport = (cfg.get("transport") or "stdio").lower()
+            if transport == "stdio":
                 # ${PYTHON_BIN} 模板 = 本项目 Python 解释器，args 按仓库相对路径补 ROOT
                 # （保留旧的纯 Python 连接器兼容，如 crm）。其它 command（如 npx）原样透传，
                 # env/args 由配置直接给 MultiServerMCPClient，支持 node 型 MCP 连接器。
                 if cfg.get("command") == "${PYTHON_BIN}":
                     cfg["command"] = sys.executable
                     cfg["args"] = [str(ROOT / a) for a in cfg.get("args", [])]
+            elif transport in ("http", "streamable-http", "streamable_http"):
+                # HTTP 型 MCP server（Streamable HTTP）：连接器配置里 transport 写
+                # "http"/"streamable-http"/"streamable_http" 均可，统一归一化为
+                # langchain-mcp-adapters 要求的 "streamable_http"，url 原样透传。
+                cfg["transport"] = "streamable_http"
             servers[name] = cfg
         try:
             mcp_client = MultiServerMCPClient(servers)

--- a/tests/test_mcp_connectors.py
+++ b/tests/test_mcp_connectors.py
@@ -1,5 +1,6 @@
-"""MCP 连接器 stdio 装配测试：验证 compiler 对 node/npx 型连接器透传 command/args/env，
-同时 ${PYTHON_BIN} 纯 Python 连接器保持旧行为（换成本项目解释器 + ROOT 相对路径）。"""
+"""MCP 连接器装配测试：验证 compiler 对 node/npx 型连接器透传 command/args/env，
+${PYTHON_BIN} 纯 Python 连接器保持旧行为（换成本项目解释器 + ROOT 相对路径），
+HTTP 型连接器（Streamable HTTP）归一化为 langchain-mcp-adapters 要求的 transport。"""
 import asyncio
 import sys
 
@@ -70,3 +71,29 @@ def test_python_bin_connector_backward_compat():
     c = servers["crm"]
     assert c["command"] == sys.executable
     assert c["args"] == [str(compiler.ROOT / "app/connectors/crm_server.py")]
+
+
+def test_http_connector_transport_normalized():
+    """HTTP 型连接器：transport "http" 归一化为 "streamable_http"，url 原样透传。"""
+    spec = EmployeeSpec(
+        id="emp_mcp3", name="测试", role="测试",
+        model="dummy-model", persona="人设",
+        mcp_servers={"scrapling": {
+            "url": "http://localhost:8000/mcp", "transport": "http"}},
+    )
+    servers = _run(spec)
+    s = servers["scrapling"]
+    assert s["transport"] == "streamable_http"
+    assert s["url"] == "http://localhost:8000/mcp"
+
+
+def test_streamable_http_alias_normalized():
+    """显式写 "streamable-http"/"streamable_http" 的配置同样归一化不报错。"""
+    for alias in ("streamable-http", "streamable_http"):
+        spec = EmployeeSpec(
+            id="emp_mcp4", name="测试", role="测试",
+            model="dummy-model", persona="人设",
+            mcp_servers={"svc": {"url": "http://x/mcp", "transport": alias}},
+        )
+        servers = _run(spec)
+        assert servers["svc"]["transport"] == "streamable_http"


### PR DESCRIPTION
## 变更内容
- compiler 装配 MCP 连接器时，对 transport "http" / "streamable-http" / "streamable_http" 归一化为 langchain-mcp-adapters 的 "streamable_http"（url 原样透传），stdio 行为不变
- 价值：资源中心可直接接入远程 HTTP 型 MCP server（无需本地子进程），如 scrapling、各类云端 MCP 服务

## 验证
- 新增 2 个单测（http 归一化 + 别名归一化），test_mcp_connectors.py 4/4 通过
- 端到端实测：接入本地 scrapling MCP server（http://localhost:8000/mcp）分配给数据分析师，对话要求抓取 https://example.com，模型成功调用 scrapling get 工具（markdown + 原始 HTML 两次调用），正确返回页面标题与正文