### PR TITLE
feat: 用户管理引入组织架构（部门树 + 用户归属）

### DIFF
--- a/backend/app/catalog/__init__.py
+++ b/backend/app/catalog/__init__.py
@@ -1,9 +1,10 @@
 """
 catalog 子包 — 数字员工目录库（catalog.db）的全部操作。
 
-拆分说明（原 catalog.py 1051 行 → 6 文件）：
+拆分说明（原 catalog.py 1051 行 → 7 文件）：
   db.py         数据库连接、建表、迁移、通用工具
   users.py      用户 CRUD + 用户-员工分配
+  orgs.py       组织（部门树）CRUD
   employees.py  员工配置读取/写入
   resources.py  技能/工具/知识库/SOP/连接器 CRUD
   seeds.py      种子数据
@@ -13,6 +14,11 @@ catalog 子包 — 数字员工目录库（catalog.db）的全部操作。
 
 # db
 from .db import GLOBAL_TOOL_NAMES, ROOT, init, _conn, _unlink, _unlink_view
+
+# orgs
+from .orgs import (
+    create_org, get_org, list_orgs, descendant_ids, update_org, delete_org,
+)
 
 # users
 from .users import (
@@ -53,6 +59,8 @@ from .seeds import (
 __all__ = [
     # db
     "GLOBAL_TOOL_NAMES", "ROOT", "init", "_unlink", "_unlink_view",
+    # orgs
+    "create_org", "get_org", "list_orgs", "descendant_ids", "update_org", "delete_org",
     # users
     "create_user", "get_user", "get_user_by_username",
     "list_users", "list_users_paged", "update_user", "set_password",

--- a/backend/app/catalog/db.py
+++ b/backend/app/catalog/db.py
@@ -21,7 +21,7 @@ DB = db_path("catalog.db")
 # tools 无删除入口，但通用列表查询会遍历它，补列以便统一 deleted_at 过滤。
 _SOFT_DELETE_TABLES = (
     "users", "employees", "skills", "tools", "knowledge_bases",
-    "sops", "connectors",
+    "sops", "connectors", "orgs",
 )
 
 _LINK_TABLES = {
@@ -69,11 +69,14 @@ def init():
     CREATE TABLE IF NOT EXISTS employee_kbs(employee_id TEXT, kb_id TEXT, PRIMARY KEY(employee_id, kb_id));
     CREATE TABLE IF NOT EXISTS employee_sops(employee_id TEXT, sop_id TEXT, PRIMARY KEY(employee_id, sop_id));
     CREATE TABLE IF NOT EXISTS employee_connectors(employee_id TEXT, connector_id TEXT, PRIMARY KEY(employee_id, connector_id));
+    CREATE TABLE IF NOT EXISTS orgs(
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, parent_id TEXT,
+      sort_order INTEGER DEFAULT 0, created_at TEXT);
     CREATE TABLE IF NOT EXISTS users(
       id TEXT PRIMARY KEY, username TEXT UNIQUE NOT NULL,
       password_hash TEXT NOT NULL, role TEXT DEFAULT 'user',
       status TEXT DEFAULT 'active', tenant_id TEXT DEFAULT 'default',
-      created_at TEXT);
+      org_id TEXT, created_at TEXT);
     CREATE TABLE IF NOT EXISTS user_employee_assignments(
       user_id TEXT NOT NULL,
       employee_id TEXT NOT NULL,
@@ -89,7 +92,15 @@ def init():
     _migrate_subagents(con)
     _migrate_ragflow_datasets(con)
     _migrate_retire_kb_entries(con)
+    _migrate_user_org(con)
     con.close()
+
+
+def _migrate_user_org(con):
+    """users 表补 org_id 列（归属组织，NULL=未分配）。幂等。"""
+    if "org_id" not in dblayer.table_columns(con, "users"):
+        con.execute("ALTER TABLE users ADD COLUMN org_id TEXT")
+    con.commit()
 
 
 def _migrate_soft_delete(con):

--- a/backend/app/catalog/orgs.py
+++ b/backend/app/catalog/orgs.py
@@ -1,0 +1,128 @@
+"""组织（部门树）CRUD。
+
+- 树形结构：parent_id 指向父部门，NULL=顶级；数据量小，前端/筛选时内存组树。
+- 删除保护：有子部门或有成员时拒绝删除（软删）。
+- 移动保护：不能把自己挂到自己或自己的后代下（防环）。
+"""
+
+import time
+import uuid
+
+from .db import _conn, _soft_delete_row
+
+
+def _new_id() -> str:
+    return "org_" + time.strftime("%Y%m%d%H%M%S") + uuid.uuid4().hex[:6]
+
+
+def create_org(name: str, parent_id: str | None = None, sort_order: int = 0) -> str | None:
+    """新建部门。父部门不存在时返回 None。"""
+    con = _conn()
+    if parent_id:
+        p = con.execute(
+            "SELECT id FROM orgs WHERE id=? AND deleted_at IS NULL", (parent_id,)).fetchone()
+        if not p:
+            con.close()
+            return None
+    oid = _new_id()
+    con.execute(
+        "INSERT INTO orgs(id,name,parent_id,sort_order,created_at) VALUES(?,?,?,?,?)",
+        (oid, name, parent_id, sort_order, time.strftime("%Y-%m-%d %H:%M:%S")))
+    con.commit()
+    con.close()
+    return oid
+
+
+def get_org(org_id: str) -> dict | None:
+    con = _conn()
+    r = con.execute(
+        "SELECT * FROM orgs WHERE id=? AND deleted_at IS NULL", (org_id,)).fetchone()
+    con.close()
+    return dict(r) if r else None
+
+
+def list_orgs() -> list[dict]:
+    """平铺列表（含各部门直属成员数），前端按 parent_id 组树。"""
+    con = _conn()
+    rows = con.execute(
+        "SELECT o.id, o.name, o.parent_id, o.sort_order, o.created_at, "
+        "(SELECT COUNT(*) FROM users u "
+        " WHERE u.org_id=o.id AND u.deleted_at IS NULL) AS member_count "
+        "FROM orgs o WHERE o.deleted_at IS NULL "
+        "ORDER BY COALESCE(o.parent_id,''), o.sort_order, o.created_at").fetchall()
+    con.close()
+    return [dict(r) for r in rows]
+
+
+def descendant_ids(org_id: str, include_self: bool = True) -> list[str]:
+    """收集某部门及其全部后代 id（筛选「父部门含子部门成员」用）。"""
+    con = _conn()
+    rows = con.execute(
+        "SELECT id, parent_id FROM orgs WHERE deleted_at IS NULL").fetchall()
+    con.close()
+    children: dict[str, list[str]] = {}
+    for r in rows:
+        children.setdefault(r["parent_id"], []).append(r["id"])
+    out: list[str] = []
+    stack = [org_id]
+    while stack:
+        cur = stack.pop()
+        out.append(cur)
+        stack.extend(children.get(cur, []))
+    return out if include_self else [i for i in out if i != org_id]
+
+
+def update_org(org_id: str, name: str | None = None, parent_id: str | None = None,
+               sort_order: int | None = None, move: bool = False) -> str | None:
+    """更新部门。move=True 才会改动 parent_id（None=挂到顶级）。
+    返回错误码：'not_found' / 'cycle' / 'bad_parent'，成功返回 None。"""
+    con = _conn()
+    row = con.execute(
+        "SELECT * FROM orgs WHERE id=? AND deleted_at IS NULL", (org_id,)).fetchone()
+    if not row:
+        con.close()
+        return "not_found"
+    if move:
+        if parent_id:
+            if parent_id == org_id or parent_id in descendant_ids(org_id, include_self=False):
+                con.close()
+                return "cycle"
+            p = con.execute(
+                "SELECT id FROM orgs WHERE id=? AND deleted_at IS NULL",
+                (parent_id,)).fetchone()
+            if not p:
+                con.close()
+                return "bad_parent"
+        con.execute("UPDATE orgs SET parent_id=? WHERE id=?", (parent_id or None, org_id))
+    if name is not None:
+        con.execute("UPDATE orgs SET name=? WHERE id=?", (name, org_id))
+    if sort_order is not None:
+        con.execute("UPDATE orgs SET sort_order=? WHERE id=?", (sort_order, org_id))
+    con.commit()
+    con.close()
+    return None
+
+
+def delete_org(org_id: str) -> str | None:
+    """软删部门。有子部门或有成员时返回错误码，成功返回 None。"""
+    con = _conn()
+    row = con.execute(
+        "SELECT id FROM orgs WHERE id=? AND deleted_at IS NULL", (org_id,)).fetchone()
+    if not row:
+        con.close()
+        return "not_found"
+    child = con.execute(
+        "SELECT id FROM orgs WHERE parent_id=? AND deleted_at IS NULL LIMIT 1",
+        (org_id,)).fetchone()
+    if child:
+        con.close()
+        return "has_children"
+    member = con.execute(
+        "SELECT id FROM users WHERE org_id=? AND deleted_at IS NULL LIMIT 1",
+        (org_id,)).fetchone()
+    if member:
+        con.close()
+        return "has_members"
+    con.close()
+    _soft_delete_row("orgs", org_id)
+    return None

--- a/backend/app/catalog/users.py
+++ b/backend/app/catalog/users.py
@@ -3,6 +3,7 @@
 import json
 import time
 import uuid
+from . import orgs as orgs_mod
 from .db import _conn, _soft_delete_row
 
 
@@ -10,8 +11,13 @@ from .db import _conn, _soft_delete_row
 # 用户管理
 # ---------------------------------------------------------------------------
 
+_USER_LIST_COLS = ("u.id, u.username, u.role, u.status, u.tenant_id, u.org_id, "
+                   "u.created_at, o.name AS org_name")
+
+
 def create_user(username: str, password_hash: str, role: str = "user",
-                tenant_id: str = "default", user_id: str | None = None) -> str:
+                tenant_id: str = "default", user_id: str | None = None,
+                org_id: str | None = None) -> str:
     # 秒级时间戳同秒会撞主键（批量建用户/测试夹具），追加随机段保证唯一
     uid = user_id or ("u_" + time.strftime("%Y%m%d%H%M%S") + uuid.uuid4().hex[:6])
     now = time.strftime("%Y-%m-%d %H:%M:%S")
@@ -21,16 +27,16 @@ def create_user(username: str, password_hash: str, role: str = "user",
         (username,)).fetchone()
     if old:
         con.execute(
-            "UPDATE users SET password_hash=?, role=?, status='active', tenant_id=?, deleted_at=NULL "
-            "WHERE username=?",
-            (password_hash, role, tenant_id, username))
+            "UPDATE users SET password_hash=?, role=?, status='active', tenant_id=?, "
+            "org_id=?, deleted_at=NULL WHERE username=?",
+            (password_hash, role, tenant_id, org_id, username))
         con.commit()
         con.close()
         return old["id"]
     con.execute(
-        "INSERT OR IGNORE INTO users(id,username,password_hash,role,status,tenant_id,created_at) "
-        "VALUES(?,?,?,?,?,?,?)",
-        (uid, username, password_hash, role, "active", tenant_id, now))
+        "INSERT OR IGNORE INTO users(id,username,password_hash,role,status,tenant_id,org_id,created_at) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (uid, username, password_hash, role, "active", tenant_id, org_id, now))
     con.commit()
     con.close()
     return uid
@@ -51,24 +57,40 @@ def get_user_by_username(username: str) -> dict | None:
     return dict(r) if r else None
 
 
-def list_users() -> list[dict]:
+def _org_filter(org_id: str | None) -> tuple[str, list]:
+    """按部门筛选（含全部子部门）的 WHERE 片段与参数。"""
+    if not org_id:
+        return "", []
+    ids = orgs_mod.descendant_ids(org_id)
+    marks = ",".join("?" for _ in ids)
+    return f" AND u.org_id IN ({marks})", list(ids)
+
+
+def list_users(org_id: str | None = None) -> list[dict]:
+    where, args = _org_filter(org_id)
     con = _conn()
     rows = con.execute(
-        "SELECT id,username,role,status,tenant_id,created_at FROM users "
-        "WHERE deleted_at IS NULL ORDER BY created_at").fetchall()
+        f"SELECT {_USER_LIST_COLS} FROM users u "
+        f"LEFT JOIN orgs o ON o.id=u.org_id AND o.deleted_at IS NULL "
+        f"WHERE u.deleted_at IS NULL{where} ORDER BY u.created_at", args).fetchall()
     con.close()
     return [dict(r) for r in rows]
 
 
-def list_users_paged(page: int = 1, page_size: int = 10) -> dict:
+def list_users_paged(page: int = 1, page_size: int = 10,
+                     org_id: str | None = None) -> dict:
     page = max(1, page)
+    where, args = _org_filter(org_id)
     con = _conn()
-    total = con.execute("SELECT COUNT(*) FROM users WHERE deleted_at IS NULL").fetchone()[0]
+    total = con.execute(
+        f"SELECT COUNT(*) FROM users u WHERE u.deleted_at IS NULL{where}", args).fetchone()[0]
     offset = (page - 1) * page_size
     rows = con.execute(
-        "SELECT id,username,role,status,tenant_id,created_at FROM users "
-        "WHERE deleted_at IS NULL ORDER BY created_at LIMIT ? OFFSET ?",
-        (page_size, offset)).fetchall()
+        f"SELECT {_USER_LIST_COLS} FROM users u "
+        f"LEFT JOIN orgs o ON o.id=u.org_id AND o.deleted_at IS NULL "
+        f"WHERE u.deleted_at IS NULL{where} "
+        f"ORDER BY u.created_at LIMIT ? OFFSET ?",
+        args + [page_size, offset]).fetchall()
     con.close()
     return {
         "items": [dict(r) for r in rows],
@@ -79,13 +101,17 @@ def list_users_paged(page: int = 1, page_size: int = 10) -> dict:
     }
 
 
-def update_user(user_id: str, role: str | None = None, status: str | None = None) -> bool:
+def update_user(user_id: str, role: str | None = None, status: str | None = None,
+                org_id: str | None = None, set_org: bool = False) -> bool:
+    """set_org=True 才会改动归属部门（org_id=None 表示移出部门）。"""
     con = _conn()
     cur = con.cursor()
     if role is not None:
         cur.execute("UPDATE users SET role=? WHERE id=?", (role, user_id))
     if status is not None:
         cur.execute("UPDATE users SET status=? WHERE id=?", (status, user_id))
+    if set_org:
+        cur.execute("UPDATE users SET org_id=? WHERE id=?", (org_id, user_id))
     ok = cur.rowcount > 0
     con.commit()
     con.close()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -34,11 +34,29 @@ class UserCreateIn(BaseModel):
     username: str
     password: str
     role: str = "user"
+    org_id: str | None = None
 
 
 class UserUpdateIn(BaseModel):
     role: str | None = None
     status: str | None = None
+    # 归属部门：仅在显式传字段时更新（None=移出部门，与「不改动」区分）
+    org_id: str | None = None
+    set_org: bool = False
+
+
+class OrgCreateIn(BaseModel):
+    name: str
+    parent_id: str | None = None
+    sort_order: int = 0
+
+
+class OrgUpdateIn(BaseModel):
+    name: str | None = None
+    parent_id: str | None = None
+    sort_order: int | None = None
+    # move=True 才会改动 parent_id（避免改名时误挂到顶级）
+    move: bool = False
 
 
 class PasswordIn(BaseModel):

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,4 +1,4 @@
-"""管理后台路由：员工/技能/工具/知识库/SOP/连接器/用户 CRUD + 分配管理。"""
+"""管理后台路由：员工/技能/工具/知识库/SOP/连接器/用户/组织 CRUD + 分配管理。"""
 
 import io
 import json
@@ -12,7 +12,8 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from app import auth, catalog, runtime, traces
-from app.models import UserCreateIn, UserUpdateIn, PasswordIn
+from app.models import (UserCreateIn, UserUpdateIn, PasswordIn,
+                        OrgCreateIn, OrgUpdateIn)
 from app.paths import PROJECT_ROOT
 
 router = APIRouter(prefix="/api/admin", dependencies=[Depends(auth.require_admin)])
@@ -292,13 +293,58 @@ async def del_connector(conn_id: str):
     return {"ok": True, "invalidated": affected}
 
 
+# ---- 组织管理 ----
+
+_ORG_ERRORS = {
+    "not_found": "部门不存在",
+    "cycle": "不能把部门移动到自身或其子部门下",
+    "bad_parent": "父部门不存在",
+    "has_children": "请先删除该部门的子部门",
+    "has_members": "该部门下仍有用户，请先移出",
+}
+
+
+@router.get("/orgs")
+async def list_orgs_api():
+    return catalog.list_orgs()
+
+
+@router.post("/orgs")
+async def create_org_api(body: OrgCreateIn):
+    if not body.name.strip():
+        return {"error": "部门名称不能为空"}
+    oid = catalog.create_org(body.name.strip(), body.parent_id, body.sort_order)
+    if not oid:
+        return {"error": "父部门不存在"}
+    return {"id": oid, "name": body.name.strip()}
+
+
+@router.put("/orgs/{oid}")
+async def update_org_api(oid: str, body: OrgUpdateIn):
+    err = catalog.update_org(oid, name=body.name.strip() if body.name else None,
+                             parent_id=body.parent_id, sort_order=body.sort_order,
+                             move=body.move)
+    if err:
+        return {"error": _ORG_ERRORS.get(err, err)}
+    return {"ok": True}
+
+
+@router.delete("/orgs/{oid}")
+async def delete_org_api(oid: str):
+    err = catalog.delete_org(oid)
+    if err:
+        return {"error": _ORG_ERRORS.get(err, err)}
+    return {"ok": True}
+
+
 # ---- 用户管理 ----
 
 @router.get("/users")
-async def list_users_api(page: int | None = None, page_size: int = 10):
+async def list_users_api(page: int | None = None, page_size: int = 10,
+                         org_id: str | None = None):
     if page:
-        return catalog.list_users_paged(page, page_size)
-    return catalog.list_users()
+        return catalog.list_users_paged(page, page_size, org_id=org_id)
+    return catalog.list_users(org_id=org_id)
 
 
 @router.post("/users")
@@ -307,7 +353,10 @@ async def create_user_api(body: UserCreateIn):
         return {"error": "用户名已存在"}
     if body.role not in ("admin", "user"):
         return {"error": "role 必须是 admin 或 user"}
-    uid = catalog.create_user(body.username, auth.hash_password(body.password), role=body.role)
+    if body.org_id and not catalog.get_org(body.org_id):
+        return {"error": "归属部门不存在"}
+    uid = catalog.create_user(body.username, auth.hash_password(body.password),
+                              role=body.role, org_id=body.org_id)
     return {"id": uid, "username": body.username, "role": body.role}
 
 
@@ -315,7 +364,10 @@ async def create_user_api(body: UserCreateIn):
 async def update_user_api(uid: str, body: UserUpdateIn, admin: dict = Depends(auth.require_admin)):
     if uid == admin["id"] and body.status == "disabled":
         return {"error": "不能禁用当前登录的管理员"}
-    ok = catalog.update_user(uid, role=body.role, status=body.status)
+    if body.set_org and body.org_id and not catalog.get_org(body.org_id):
+        return {"error": "归属部门不存在"}
+    ok = catalog.update_user(uid, role=body.role, status=body.status,
+                             org_id=body.org_id, set_org=body.set_org)
     return {"ok": ok}
 
 

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -1,18 +1,42 @@
-<!-- 用户管理：用户列表 CRUD + 员工分配管理 + 密码重置 -->
+<!-- 用户管理：组织树 + 用户列表 CRUD + 员工分配管理 + 密码重置 -->
 <template>
   <div class="users-page">
-    <div class="users-toolbar">
-      <span class="users-title">用户管理</span>
-      <n-button size="small" type="primary" @click="openCreate">+ 新建用户</n-button>
-    </div>
+    <div class="users-layout">
+      <!-- 左侧：组织树 -->
+      <div class="org-panel">
+        <div class="org-toolbar">
+          <span class="org-title">组织架构</span>
+          <n-button size="tiny" quaternary type="primary" @click="openOrgCreate(null)">+ 部门</n-button>
+        </div>
+        <n-tree
+          block-line
+          :data="orgTree"
+          :selected-keys="selectedOrg ? [selectedOrg] : []"
+          :default-expand-all="true"
+          key-field="id"
+          label-field="label"
+          children-field="children"
+          :render-suffix="renderOrgSuffix"
+          @update:selected-keys="onOrgSelect"
+        />
+      </div>
 
-    <n-data-table :columns="columns" :data="users" :bordered="false" size="small" />
-    <PaginationBar
-      :page="page"
-      :page-size="pageSize"
-      :total="total"
-      @update:page="onPageChange"
-    />
+      <!-- 右侧：用户列表 -->
+      <div class="user-panel">
+        <div class="users-toolbar">
+          <span class="users-title">{{ selectedOrgName ? `${selectedOrgName} · 用户` : '全部用户' }}</span>
+          <n-button size="small" type="primary" @click="openCreate">+ 新建用户</n-button>
+        </div>
+
+        <n-data-table :columns="columns" :data="users" :bordered="false" size="small" />
+        <PaginationBar
+          :page="page"
+          :page-size="pageSize"
+          :total="total"
+          @update:page="onPageChange"
+        />
+      </div>
+    </div>
 
     <!-- 新建用户弹窗 -->
     <n-modal v-model:show="createModal" preset="card" title="新建用户" style="width:400px">
@@ -22,8 +46,31 @@
         <n-form-item label="角色">
           <n-select v-model:value="createForm.role" :options="[{label:'普通用户（user）',value:'user'},{label:'管理员（admin）',value:'admin'}]" />
         </n-form-item>
+        <n-form-item label="部门">
+          <n-tree-select
+            v-model:value="createForm.org_id"
+            :options="orgTreeSelect"
+            placeholder="不归属任何部门"
+            clearable
+          />
+        </n-form-item>
       </n-form>
       <template #footer><n-space><n-button @click="createModal=false">取消</n-button><n-button type="primary" @click="doCreate">创建</n-button></n-space></template>
+    </n-modal>
+
+    <!-- 调整部门弹窗 -->
+    <n-modal v-model:show="orgMoveModal" preset="card" :title="`调整部门 · ${orgMoveTarget.name}`" style="width:400px">
+      <n-form label-placement="left" :label-width="70" size="small">
+        <n-form-item label="部门">
+          <n-tree-select
+            v-model:value="orgMoveForm.org_id"
+            :options="orgTreeSelect"
+            placeholder="不归属任何部门"
+            clearable
+          />
+        </n-form-item>
+      </n-form>
+      <template #footer><n-space><n-button @click="orgMoveModal=false">取消</n-button><n-button type="primary" @click="doOrgMove">保存</n-button></n-space></template>
     </n-modal>
 
     <!-- 重置密码弹窗 -->
@@ -47,12 +94,28 @@
       </div>
       <template #footer><n-space><n-button @click="assignModal=false">取消</n-button><n-button type="primary" @click="doSaveAssign">保存分配</n-button></n-space></template>
     </n-modal>
+
+    <!-- 部门编辑弹窗（新建/重命名） -->
+    <n-modal v-model:show="orgEditModal" preset="card" :title="orgEditForm.id ? '编辑部门' : '新建部门'" style="width:400px">
+      <n-form label-placement="left" :label-width="70" size="small">
+        <n-form-item label="名称"><n-input v-model:value="orgEditForm.name" placeholder="部门名称" /></n-form-item>
+        <n-form-item label="上级部门">
+          <n-tree-select
+            v-model:value="orgEditForm.parent_id"
+            :options="orgTreeSelectForEdit"
+            placeholder="作为顶级部门"
+            clearable
+          />
+        </n-form-item>
+      </n-form>
+      <template #footer><n-space><n-button @click="orgEditModal=false">取消</n-button><n-button type="primary" @click="doOrgEditSave">保存</n-button></n-space></template>
+    </n-modal>
   </div>
 </template>
 
 <script setup>
 import { ref, reactive, computed, h, onMounted } from 'vue'
-import { NButton, NTag, NSpace, useDialog, useMessage } from 'naive-ui'
+import { NButton, NTag, NSpace, NDropdown, useDialog, useMessage } from 'naive-ui'
 import { useAuthStore } from '../stores/auth.js'
 import api from '../api.js'
 import PaginationBar from '../components/PaginationBar.vue'
@@ -69,9 +132,22 @@ const pageSize = ref(10)
 const total = ref(0)
 const loading = ref(false)
 
+// 组织树
+const orgs = ref([])
+const selectedOrg = ref(null)   // null = 全部用户
+
 // 新建用户
 const createModal = ref(false)
-const createForm = reactive({ username: '', password: '', role: 'user' })
+const createForm = reactive({ username: '', password: '', role: 'user', org_id: null })
+
+// 调整用户部门
+const orgMoveModal = ref(false)
+const orgMoveTarget = reactive({ id: '', name: '' })
+const orgMoveForm = reactive({ org_id: null })
+
+// 部门编辑（新建/重命名）
+const orgEditModal = ref(false)
+const orgEditForm = reactive({ id: '', name: '', parent_id: null })
 
 // 重置密码
 const pwModal = ref(false)
@@ -85,6 +161,143 @@ const assignList = ref([])
 
 function fmtTime(s) { return (s || '').replace(' ', ' ').slice(5, 16) }
 
+// ---- 组织树 ----
+
+const orgTree = computed(() => buildTree(null))
+
+function buildTree(parentId) {
+  return orgs.value
+    .filter(o => (o.parent_id || null) === parentId)
+    .map(o => {
+      const children = buildTree(o.id)
+      return {
+        id: o.id,
+        label: o.name,
+        member_count: o.member_count,
+        children: children.length ? children : undefined,
+        isLeaf: !children.length,
+      }
+    })
+}
+
+// TreeSelect 选项（用户归属选择，可清空=不归属）
+const orgTreeSelect = computed(() => toSelectOptions(orgTree.value))
+
+function toSelectOptions(nodes) {
+  return (nodes || []).map(n => ({
+    key: n.id, label: n.label, children: toSelectOptions(n.children),
+  }))
+}
+
+// 编辑部门时的父部门选项（排除自身及其子树，防环）
+const orgTreeSelectForEdit = computed(() => {
+  if (!orgEditForm.id) return orgTreeSelect.value
+  const excluded = new Set([orgEditForm.id])
+  const collect = (nodes) => (nodes || []).filter(n => {
+    if (excluded.has(n.id)) { collectChildren(n); return false }
+    return true
+  }).map(n => ({ key: n.key, label: n.label, children: collect(n.children) }))
+  const collectChildren = (n) => (n.children || []).forEach(c => { excluded.add(c.id); collectChildren(c) })
+  return collect(orgTree.value)
+})
+
+const selectedOrgName = computed(() => {
+  const o = orgs.value.find(x => x.id === selectedOrg.value)
+  return o ? o.name : ''
+})
+
+function renderOrgSuffix({ option }) {
+  return h('div', { class: 'org-node-actions' }, [
+    h('span', { class: 'org-count' }, option.member_count ? `${option.member_count}人` : ''),
+    h(NDropdown, {
+      trigger: 'click',
+      size: 'small',
+      options: [
+        { label: '新建子部门', key: 'add' },
+        { label: '重命名', key: 'rename' },
+        { label: '删除', key: 'del' },
+      ],
+      onSelect: (key) => onOrgAction(key, option),
+    }, { default: () => h('span', { class: 'org-more' }, '···') }),
+  ])
+}
+
+function onOrgAction(key, node) {
+  if (key === 'add') openOrgCreate(node.id)
+  else if (key === 'rename') openOrgRename(node.id)
+  else if (key === 'del') delOrg(node.id)
+}
+
+function onOrgSelect(keys) {
+  selectedOrg.value = keys[0] || null
+  page.value = 1
+  loadUsers()
+}
+
+async function loadOrgs() {
+  try {
+    const { data } = await api.get('/admin/orgs')
+    orgs.value = data || []
+  } catch {}
+}
+
+function openOrgCreate(parentId) {
+  orgEditForm.id = ''
+  orgEditForm.name = ''
+  orgEditForm.parent_id = parentId || null
+  orgEditModal.value = true
+}
+
+function openOrgRename(orgId) {
+  const o = orgs.value.find(x => x.id === orgId)
+  if (!o) return
+  orgEditForm.id = orgId
+  orgEditForm.name = o.name
+  orgEditForm.parent_id = o.parent_id || null
+  orgEditModal.value = true
+}
+
+async function doOrgEditSave() {
+  if (!orgEditForm.name.trim()) { message.warning('请填写部门名称'); return }
+  try {
+    const body = { name: orgEditForm.name.trim(), parent_id: orgEditForm.parent_id || null }
+    let res
+    if (orgEditForm.id) {
+      // 编辑：parent_id 变化时带 move 标记
+      const o = orgs.value.find(x => x.id === orgEditForm.id)
+      const moved = (o.parent_id || null) !== body.parent_id
+      res = await api.put(`/admin/orgs/${orgEditForm.id}`, { ...body, move: moved })
+    } else {
+      res = await api.post('/admin/orgs', body)
+    }
+    if (res.data.error) { message.error(res.data.error); return }
+    message.success('已保存')
+    orgEditModal.value = false
+    await loadOrgs()
+  } catch (e) { message.error('保存失败：' + e.message) }
+}
+
+function delOrg(orgId) {
+  const o = orgs.value.find(x => x.id === orgId)
+  if (!o) return
+  dialog.warning({
+    title: '删除部门', content: `确认删除部门「${o.name}」？需先清空其子部门与成员。`,
+    positiveText: '删除', negativeText: '取消',
+    onPositiveClick: async () => {
+      try {
+        const { data } = await api.delete(`/admin/orgs/${orgId}`)
+        if (data.error) { message.error(data.error); return }
+        message.success('已删除')
+        if (selectedOrg.value === orgId) selectedOrg.value = null
+        await loadOrgs()
+        await loadUsers()
+      } catch (e) { message.error(e.message) }
+    },
+  })
+}
+
+// ---- 用户列表 ----
+
 const columns = computed(() => [
   {
     title: '用户名', key: 'username',
@@ -92,6 +305,12 @@ const columns = computed(() => [
       row.username,
       row.id === 'u_admin' ? h('span', { style: 'color:#94a3b8;font-size:11px;margin-left:6px' }, '(初始)') : null,
     ]),
+  },
+  {
+    title: '部门', key: 'org_name', width: 140,
+    render: (row) => row.org_name
+      ? h(NTag, { size: 'small', round: true, bordered: false }, { default: () => row.org_name })
+      : h('span', { style: 'color:#cbd5e1' }, '—'),
   },
   {
     title: '角色', key: 'role', width: 100,
@@ -103,12 +322,13 @@ const columns = computed(() => [
   },
   { title: '创建时间', key: 'created_at', width: 120, render: (row) => fmtTime(row.created_at) },
   {
-    title: '操作', key: 'actions', width: 280,
+    title: '操作', key: 'actions', width: 320,
     render: (row) => {
       const isSelf = row.id === auth.user?.id
       return h(NSpace, { size: 'small' }, {
         default: () => [
           h(NButton, { size: 'tiny', quaternary: true, type: 'primary', onClick: () => openAssign(row) }, { default: () => '分配员工' }),
+          h(NButton, { size: 'tiny', quaternary: true, onClick: () => openOrgMove(row) }, { default: () => '调部门' }),
           h(NButton, { size: 'tiny', quaternary: true, onClick: () => openResetPw(row) }, { default: () => '改密' }),
           h(NButton, { size: 'tiny', quaternary: true, onClick: () => toggleStatus(row) }, { default: () => row.status === 'active' ? '禁用' : '启用' }),
           h(NButton, { size: 'tiny', quaternary: true, type: 'error', disabled: isSelf, onClick: () => delUser(row) }, { default: () => '删除' }),
@@ -121,7 +341,9 @@ const columns = computed(() => [
 async function loadUsers() {
   loading.value = true
   try {
-    const { data } = await api.get('/admin/users', { params: { page: page.value, page_size: pageSize.value } })
+    const params = { page: page.value, page_size: pageSize.value }
+    if (selectedOrg.value) params.org_id = selectedOrg.value
+    const { data } = await api.get('/admin/users', { params })
     users.value = data.items || []
     total.value = data.total || 0
   } catch {} finally { loading.value = false }
@@ -134,6 +356,8 @@ function onPageChange(p) {
 
 function openCreate() {
   createForm.username = ''; createForm.password = ''; createForm.role = 'user'
+  // 默认选中当前筛选的部门
+  createForm.org_id = selectedOrg.value || null
   createModal.value = true
 }
 
@@ -144,8 +368,26 @@ async function doCreate() {
     if (data.error) { message.error(data.error); return }
     message.success('已创建')
     createModal.value = false
-    await loadUsers()
+    await Promise.all([loadUsers(), loadOrgs()])
   } catch (e) { message.error('创建失败：' + e.message) }
+}
+
+function openOrgMove(row) {
+  orgMoveTarget.id = row.id; orgMoveTarget.name = row.username
+  orgMoveForm.org_id = row.org_id || null
+  orgMoveModal.value = true
+}
+
+async function doOrgMove() {
+  try {
+    const { data } = await api.put(`/admin/users/${orgMoveTarget.id}`, {
+      org_id: orgMoveForm.org_id || null, set_org: true,
+    })
+    if (data.error) { message.error(data.error); return }
+    message.success('已调整部门')
+    orgMoveModal.value = false
+    await Promise.all([loadUsers(), loadOrgs()])
+  } catch (e) { message.error('调整失败：' + e.message) }
 }
 
 function openResetPw(row) {
@@ -184,7 +426,7 @@ function delUser(row) {
     title: '删除用户', content: `确认删除用户「${row.username}」？该操作不可恢复。`,
     positiveText: '删除', negativeText: '取消',
     onPositiveClick: async () => {
-      try { await api.delete(`/admin/users/${row.id}`); message.success('已删除'); await loadUsers() } catch (e) { message.error(e.message) }
+      try { await api.delete(`/admin/users/${row.id}`); message.success('已删除'); await Promise.all([loadUsers(), loadOrgs()]) } catch (e) { message.error(e.message) }
     },
   })
 }
@@ -214,11 +456,30 @@ async function doSaveAssign() {
   } catch (e) { message.error('保存失败：' + e.message) }
 }
 
-onMounted(loadUsers)
+onMounted(async () => {
+  await loadOrgs()
+  await loadUsers()
+})
 </script>
 
 <style scoped>
 .users-page { padding: 24px; }
+.users-layout { display: flex; gap: 16px; align-items: flex-start; }
+.org-panel {
+  width: 240px; flex-shrink: 0; padding: 12px;
+  border: 1px solid #e2e8f0; border-radius: 10px;
+  background: #fff; max-height: calc(100vh - 140px); overflow-y: auto;
+}
+.org-toolbar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.org-title { font-size: 13px; font-weight: 600; color: #0f172a; }
+.org-node-actions { display: flex; align-items: center; gap: 6px; }
+.org-count { font-size: 11px; color: #94a3b8; }
+.org-more {
+  cursor: pointer; color: #94a3b8; font-weight: 700; letter-spacing: 1px;
+  padding: 0 4px; border-radius: 4px;
+}
+.org-more:hover { color: #2563eb; background: #eff6ff; }
+.user-panel { flex: 1; min-width: 0; }
 .users-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
 .users-title { font-size: 15px; font-weight: 600; color: #0f172a; flex: 1; }
 .assign-hint { font-size: 13px; color: #64748b; margin-bottom: 16px; line-height: 1.6; }

--- a/tests/test_orgs.py
+++ b/tests/test_orgs.py
@@ -1,0 +1,110 @@
+"""组织（部门树）+ 用户归属回归测试（离线，用临时 sqlite 库）。"""
+import pytest
+
+from app import catalog
+from app.catalog import orgs
+
+
+@pytest.fixture()
+def seeded():
+    """建一棵测试树：总部 > (华东, 华北)；华东 > 销售部。"""
+    root = orgs.create_org("总部")
+    east = orgs.create_org("华东大区", parent_id=root)
+    north = orgs.create_org("华北大区", parent_id=root)
+    sales = orgs.create_org("销售部", parent_id=east)
+    return {"root": root, "east": east, "north": north, "sales": sales}
+
+
+def test_create_and_list(seeded):
+    lst = {o["name"]: o for o in orgs.list_orgs()}
+    assert set(lst) == {"总部", "华东大区", "华北大区", "销售部"}
+    assert lst["销售部"]["parent_id"] == seeded["east"]
+
+
+def test_create_with_bad_parent():
+    assert orgs.create_org("孤儿", parent_id="org_not_exist") is None
+
+
+def test_descendants_include_subtree(seeded):
+    ids = orgs.descendant_ids(seeded["root"])
+    assert set(ids) == set(seeded.values())
+    # 不含自身
+    assert orgs.descendant_ids(seeded["east"], include_self=False) == [seeded["sales"]]
+
+
+def test_update_rename_without_move(seeded):
+    # 不带 move：改名不影响 parent_id
+    assert orgs.update_org(seeded["sales"], name="销售一部") is None
+    o = orgs.get_org(seeded["sales"])
+    assert o["name"] == "销售一部"
+    assert o["parent_id"] == seeded["east"]
+
+
+def test_update_move_cycle_rejected(seeded):
+    # 把父部门挂到子部门下 → cycle
+    assert orgs.update_org(seeded["east"], parent_id=seeded["sales"], move=True) == "cycle"
+    # 挂到自己 → cycle
+    assert orgs.update_org(seeded["east"], parent_id=seeded["east"], move=True) == "cycle"
+
+
+def test_update_move_to_bad_parent(seeded):
+    assert orgs.update_org(seeded["sales"], parent_id="org_not_exist", move=True) == "bad_parent"
+
+
+def test_update_move_ok(seeded):
+    assert orgs.update_org(seeded["sales"], parent_id=seeded["north"], move=True) is None
+    assert orgs.get_org(seeded["sales"])["parent_id"] == seeded["north"]
+    # 挂到顶级
+    assert orgs.update_org(seeded["sales"], parent_id=None, move=True) is None
+    assert orgs.get_org(seeded["sales"])["parent_id"] is None
+
+
+def test_delete_protection(seeded):
+    uid = catalog.create_user("org_user_1", "x", org_id=seeded["sales"])
+    assert orgs.delete_org(seeded["sales"]) == "has_members"
+    assert orgs.delete_org(seeded["root"]) == "has_children"
+    # 移出成员后可删
+    catalog.update_user(uid, org_id=None, set_org=True)
+    assert orgs.delete_org(seeded["sales"]) is None
+    assert orgs.get_org(seeded["sales"]) is None
+
+
+def test_delete_not_found():
+    assert orgs.delete_org("org_not_exist") == "not_found"
+
+
+def test_user_org_and_filter(seeded):
+    uid1 = catalog.create_user("org_user_a", "x", org_id=seeded["sales"])
+    uid2 = catalog.create_user("org_user_b", "x", org_id=seeded["north"])
+    uid3 = catalog.create_user("org_user_c", "x")  # 无部门
+
+    # 列表带部门名
+    rows = {u["username"]: u for u in catalog.list_users()}
+    assert rows["org_user_a"]["org_name"] == "销售部"
+    assert rows["org_user_b"]["org_name"] == "华北大区"
+    assert rows["org_user_c"]["org_name"] is None
+
+    # 父部门筛选含子部门成员
+    names = {u["username"] for u in catalog.list_users(org_id=seeded["east"])}
+    assert names == {"org_user_a"}
+    names = {u["username"] for u in catalog.list_users(org_id=seeded["root"])}
+    assert names == {"org_user_a", "org_user_b"}
+
+    # 分页筛选
+    paged = catalog.list_users_paged(1, 10, org_id=seeded["east"])
+    assert paged["total"] == 1 and paged["items"][0]["username"] == "org_user_a"
+
+    # 调部门
+    catalog.update_user(uid1, org_id=seeded["north"], set_org=True)
+    assert {u["username"] for u in catalog.list_users(org_id=seeded["north"])} == \
+        {"org_user_a", "org_user_b"}
+    # set_org=False 不影响归属
+    catalog.update_user(uid2, role="admin")
+    assert catalog.get_user(uid2)["org_id"] == seeded["north"]
+
+
+def test_user_org_name_after_org_renamed(seeded):
+    uid = catalog.create_user("org_user_d", "x", org_id=seeded["east"])
+    orgs.update_org(seeded["east"], name="华东区")
+    rows = {u["username"]: u for u in catalog.list_users()}
+    assert rows["org_user_d"]["org_name"] == "华东区"


### PR DESCRIPTION
## 变更内容

企业真实场景需要的组织架构能力，本期落地「部门树 + 用户归属」：

### 后端
- **catalog 库新表 `orgs`**（parent_id 树形 + 软删）；`users` 表补 `org_id` 列（启动幂等迁移，SQLite/PostgreSQL 双后端通用）
- **`catalog/orgs.py`**：部门 CRUD
  - 环检测：不能把部门移动到自身或其子部门下
  - 删除保护：有子部门或有成员时拒绝删除（软删）
  - `list_orgs` 带各部门直属成员数
- **users**：创建/更新支持归属部门；列表 LEFT JOIN 带部门名；**按部门筛选自动包含全部子部门成员**（点父部门看到整棵子树的成员）
- **新端点**：`GET/POST /api/admin/orgs`、`PUT/DELETE /api/admin/orgs/{oid}`；`GET /api/admin/users` 支持 `org_id` 筛选

### 前端（用户管理页重构为左树右表）
- 左侧组织树：点击节点筛选右侧用户列表；节点 `···` 菜单支持新建子部门/重命名/删除；显示各部门人数
- 用户列表新增「部门」列；操作列新增「调部门」
- 新建用户弹窗支持选部门（默认带出当前筛选部门）；部门选择器排除自身子树防环

## 验证

- [x] `tests/test_orgs.py` 11 项测试通过（CRUD / 环检测 / 删除保护 / 用户归属 / 树形筛选 / 部门改名后用户列表联动）
- [x] 存量回归：test_catalog / test_auth 通过
- [x] 前端 `npx vite build` 通过
- [x] PG 后端实测：orgs 表自动迁移创建、建部门/删部门/用户列表 org_name 字段正常

## 范围说明

本期不含（后续迭代）：组织级数字员工授权（部门成员继承）、组织数据隔离、部门负责人/审批链。