### PR TITLE
feat: 员工管理重构为列表 + 详情独立配置页

### DIFF
--- a/backend/app/catalog/employees.py
+++ b/backend/app/catalog/employees.py
@@ -238,30 +238,49 @@ def create_employee(data: dict) -> str:
 
 
 def update_employee(emp_id: str, data: dict) -> bool:
+    """更新员工配置。支持部分更新：payload 未出现的字段/资源类型沿用现值。
+
+    例如只传 {"connectors": [...]} 时，名称/人设/技能等其余配置保持不变，
+    各配置页可独立保存互不覆盖。
+    """
     con = _conn()
     cur = con.cursor()
-    interrupt_on = _build_interrupt_on(data.get("tools", []))
+    row = cur.execute("SELECT * FROM employees WHERE id=? AND deleted_at IS NULL",
+                      (emp_id,)).fetchone()
+    if not row:
+        con.close()
+        return False
+    # 现有关联（payload 未提供的资源类型沿用）
+    def _links(col, table):
+        return [x[0] for x in cur.execute(
+            f"SELECT {col} FROM {table} WHERE employee_id=?", (emp_id,))]
+    existing = {
+        "skills": _links("skill_id", "employee_skills"),
+        "tools": _links("tool_id", "employee_tools"),
+        "kbs": _links("kb_id", "employee_kbs"),
+        "sops": _links("sop_id", "employee_sops"),
+        "connectors": _links("connector_id", "employee_connectors"),
+    }
+    tools = data.get("tools", existing["tools"])
+    interrupt_on = _build_interrupt_on(tools)
     subagents = data.get("subagents")
     if subagents is None:
-        row = cur.execute("SELECT subagents FROM employees WHERE id=?", (emp_id,)).fetchone()
-        subagents = json.loads(row["subagents"]) if row and row["subagents"] else []
+        subagents = json.loads(row["subagents"]) if row["subagents"] else []
     subagent_policy = data.get("subagent_policy")
     if subagent_policy is None:
-        row = cur.execute("SELECT subagent_policy FROM employees WHERE id=?", (emp_id,)).fetchone()
-        subagent_policy = row["subagent_policy"] or "" if row else ""
+        subagent_policy = row["subagent_policy"] or ""
     cur.execute(
         "UPDATE employees SET name=?,role=?,model=?,persona=?,backend=?,"
         "interrupt_on=?,subagents=?,subagent_policy=?,updated_at=? WHERE id=?",
-        (data.get("name", emp_id), data.get("role", ""), data.get("model", ""),
-         data.get("persona", ""), data.get("backend", "state"),
+        (data.get("name", row["name"]), data.get("role", row["role"] or ""),
+         data.get("model", row["model"] or ""), data.get("persona", row["persona"] or ""),
+         data.get("backend", row["backend"] or "state"),
          json.dumps(interrupt_on, ensure_ascii=False),
          json.dumps(subagents, ensure_ascii=False),
          subagent_policy,
          time.strftime("%Y-%m-%d %H:%M:%S"), emp_id))
-    if cur.rowcount == 0:
-        con.close()
-        return False
-    _set_links(cur, emp_id, data)
+    merged = {key: data.get(key, existing[key]) for key in existing}
+    _set_links(cur, emp_id, merged)
     con.commit()
     con.close()
     return True

--- a/frontend/src/components/employee/ResourcePicker.vue
+++ b/frontend/src/components/employee/ResourcePicker.vue
@@ -1,0 +1,133 @@
+<!-- 通用资源勾选组件：搜索 + 全选/清空 + 勾选列表 + 独立保存。
+     供技能/工具/SOP 等结构化列表页复用；知识库/连接器等需要差异化展示的页面自建布局。 -->
+<template>
+  <div class="picker">
+    <div class="picker-head">
+      <div>
+        <div class="picker-title">{{ title }}<span class="picker-count">已选 {{ selectedSet.size }} / {{ items.length }}</span></div>
+        <div v-if="hint" class="picker-hint">{{ hint }}</div>
+      </div>
+      <div class="picker-ops">
+        <n-input v-model:value="keyword" size="small" clearable placeholder="搜索名称/描述…" style="width: 200px" />
+        <n-button size="small" quaternary @click="selectAll(true)">全选</n-button>
+        <n-button size="small" quaternary @click="selectAll(false)">清空</n-button>
+      </div>
+    </div>
+
+    <div v-if="!filtered.length" class="picker-empty">{{ keyword ? '无匹配项' : '暂无可选项' }}</div>
+    <div v-else class="picker-list">
+      <label
+        v-for="it in filtered" :key="it.id"
+        class="picker-item" :class="{ on: selectedSet.has(it.id) }"
+      >
+        <input type="checkbox" :checked="selectedSet.has(it.id)" @change="toggle(it.id, $event)" />
+        <div class="item-main">
+          <div class="item-name">
+            {{ it.name }}
+            <span v-for="t in it.tags || []" :key="t.label" class="item-tag" :class="t.type">{{ t.label }}</span>
+          </div>
+          <div v-if="it.description" class="item-desc">{{ it.description }}</div>
+        </div>
+      </label>
+    </div>
+
+    <div class="picker-foot">
+      <n-button type="primary" size="small" :loading="saving" :disabled="!dirty" @click="save">
+        保存{{ dirty ? '（有未保存修改）' : '' }}
+      </n-button>
+      <n-button v-if="dirty" size="small" quaternary @click="reset">还原</n-button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useMessage } from 'naive-ui'
+import api from '../../api.js'
+
+defineOptions({ name: 'ResourcePicker' })
+
+const props = defineProps({
+  employee: { type: Object, required: true },
+  fieldKey: { type: String, required: true },   // PUT 的字段名：skills / tools / sops
+  title: { type: String, required: true },
+  hint: { type: String, default: '' },
+  items: { type: Array, default: () => [] },    // [{id, name, description, tags:[{label,type}]}]
+})
+const emit = defineEmits(['changed'])
+
+const message = useMessage()
+const keyword = ref('')
+const saving = ref(false)
+const selectedSet = ref(new Set())
+
+const initialIds = computed(() => new Set(props.employee?.[props.fieldKey] || []))
+const dirty = computed(() =>
+  selectedSet.value.size !== initialIds.value.size ||
+  [...selectedSet.value].some(id => !initialIds.value.has(id)))
+
+watch(() => props.employee, () => reset(), { immediate: true })
+
+const filtered = computed(() => {
+  const kw = keyword.value.trim().toLowerCase()
+  if (!kw) return props.items
+  return props.items.filter(it =>
+    (it.name || '').toLowerCase().includes(kw) ||
+    (it.description || '').toLowerCase().includes(kw))
+})
+
+function reset() {
+  selectedSet.value = new Set(props.employee?.[props.fieldKey] || [])
+}
+
+function toggle(id, e) {
+  const s = new Set(selectedSet.value)
+  if (e.target.checked) s.add(id)
+  else s.delete(id)
+  selectedSet.value = s
+}
+
+function selectAll(on) {
+  selectedSet.value = on
+    ? new Set(props.items.map(it => it.id))
+    : new Set()
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const { data } = await api.put(`/admin/employees/${props.employee.id}`, {
+      [props.fieldKey]: [...selectedSet.value],
+    })
+    if (data.error) { message.error('保存失败：' + data.error); return }
+    message.success('已保存')
+    emit('changed')
+  } catch (e) {
+    message.error('保存出错：' + e.message)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+.picker { max-width: 860px; }
+.picker-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+.picker-title { font-size: 14px; font-weight: 600; color: #334155; }
+.picker-count { font-size: 12px; font-weight: 400; color: #94a3b8; margin-left: 10px; }
+.picker-hint { font-size: 12px; color: #94a3b8; margin-top: 4px; line-height: 1.6; max-width: 520px; }
+.picker-ops { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.picker-empty { font-size: 13px; color: #94a3b8; padding: 32px 0; text-align: center; background: #fafbfc; border-radius: 8px; }
+.picker-list { display: flex; flex-direction: column; gap: 8px; }
+.picker-item { display: flex; align-items: flex-start; gap: 10px; padding: 10px 14px; border: 1px solid #e2e8f0; border-radius: 8px; background: #fff; cursor: pointer; transition: all 0.15s; }
+.picker-item:hover { border-color: #93c5fd; }
+.picker-item.on { background: #eff6ff; border-color: #3b82f6; }
+.picker-item input { margin-top: 3px; accent-color: #3b82f6; }
+.item-main { flex: 1; min-width: 0; }
+.item-name { font-size: 13px; font-weight: 500; color: #0f172a; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.item-desc { font-size: 12px; color: #64748b; margin-top: 3px; line-height: 1.5; }
+.item-tag { font-size: 10px; padding: 1px 7px; border-radius: 8px; background: #f1f5f9; color: #64748b; font-weight: 400; }
+.item-tag.warn { background: #fffbeb; color: #b45309; }
+.item-tag.info { background: #ecfeff; color: #0e7490; }
+.picker-foot { margin-top: 14px; display: flex; gap: 8px; }
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -33,6 +33,18 @@ const routes = [
       { path: 'history', name: 'history', component: () => import('../views/HistoryView.vue') },
       { path: 'trace', name: 'trace', component: () => import('../views/TraceView.vue') },
       { path: 'admin', name: 'admin', component: () => import('../views/AdminView.vue') },
+      {
+        path: 'admin/employee/:id',
+        component: () => import('../views/employee/EmployeeDetailView.vue'),
+        children: [
+          { path: '', name: 'employee-basic', component: () => import('../views/employee/BasicInfoPage.vue') },
+          { path: 'skills', name: 'employee-skills', component: () => import('../views/employee/SkillsPage.vue') },
+          { path: 'tools', name: 'employee-tools', component: () => import('../views/employee/ToolsPage.vue') },
+          { path: 'knowledge-bases', name: 'employee-kbs', component: () => import('../views/employee/KnowledgeBasesPage.vue') },
+          { path: 'sops', name: 'employee-sops', component: () => import('../views/employee/SopsPage.vue') },
+          { path: 'connectors', name: 'employee-connectors', component: () => import('../views/employee/ConnectorsPage.vue') },
+        ],
+      },
       { path: 'users', name: 'users', component: () => import('../views/UsersView.vue') },
       { path: 'resources', name: 'resources', component: () => import('../views/ResourcesView.vue') },
       { path: 'ontology', name: 'ontology', component: () => import('../views/OntologyView.vue') },

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,32 +1,42 @@
-<!-- 员工管理：左侧员工列表 + 右侧编辑表单（名称/模型/后端/人设/技能/工具/SOP/连接器） -->
+<!-- 员工管理：员工列表入口（卡片网格 + 新建弹窗）。基础信息与技能/工具/知识库/SOP/连接器
+     的配置在员工详情页的各独立子页中完成，本页只做总览与跳转。 -->
 <template>
-  <div class="admin-layout">
-    <!-- 左侧：员工列表 -->
-    <div class="emp-list-panel">
-      <div class="list-head">
-        <span class="list-title">员工</span>
-        <n-button size="tiny" type="primary" @click="newEmp">+ 新建</n-button>
+  <div class="emp-list-page">
+    <div class="page-head">
+      <div>
+        <div class="page-title">员工管理</div>
+        <div class="page-sub">配置数字员工的基础信息与技能 / 工具 / 知识库 / SOP / 连接器</div>
       </div>
-      <div class="list-body">
-        <div v-if="!employees.length" class="list-empty">暂无员工，点击「+ 新建」</div>
-        <div
-          v-for="e in employees" :key="e.id"
-          class="emp-item"
-          :class="{ active: current?.id === e.id }"
-          @click="loadEmp(e.id)"
-        >
-          <div class="emp-name">{{ e.name }}</div>
-          <div class="emp-role">{{ e.role || '' }} · {{ e.backend }}</div>
+      <n-button type="primary" @click="openNew">+ 新建员工</n-button>
+    </div>
+
+    <div v-if="loading" class="page-empty">加载中…</div>
+    <div v-else-if="!employees.length" class="page-empty">暂无员工，点击右上角「新建员工」创建</div>
+    <div v-else class="cards">
+      <div v-for="e in employees" :key="e.id" class="emp-card" @click="goDetail(e.id)">
+        <div class="card-top">
+          <div class="avatar">{{ (e.name || '?').slice(0, 1) }}</div>
+          <div class="card-title">
+            <div class="name">{{ e.name }}</div>
+            <div class="role">{{ e.role || '未设置角色' }}</div>
+          </div>
+          <span class="backend-tag">{{ e.backend || 'state' }}</span>
         </div>
+        <div class="model">{{ e.model || '未设置模型' }}</div>
+        <div class="stats">
+          <span>技能 {{ (e.skills || []).length }}</span>
+          <span>工具 {{ (e.tools || []).length }}</span>
+          <span>知识库 {{ (e.kbs || []).length }}</span>
+          <span>SOP {{ (e.sops || []).length }}</span>
+          <span>连接器 {{ (e.connectors || []).length }}</span>
+        </div>
+        <div class="card-enter">配置详情 →</div>
       </div>
     </div>
 
-    <!-- 右侧：表单 -->
-    <div class="form-panel">
-      <n-form label-placement="left" :label-width="100" size="small">
-        <n-form-item label="员工 ID">
-          <n-input :value="current?.id || ''" placeholder="保存后自动生成" readonly />
-        </n-form-item>
+    <!-- 新建弹窗：只填基础信息，创建后跳详情页继续配置资源 -->
+    <n-modal v-model:show="showNew" preset="card" title="新建员工" style="width: 560px">
+      <n-form label-placement="left" :label-width="90" size="small">
         <n-form-item label="名称 *" required>
           <n-input v-model:value="form.name" placeholder="如：小苏" />
         </n-form-item>
@@ -40,203 +50,106 @@
           <n-select v-model:value="form.backend" :options="backendOptions" />
         </n-form-item>
         <n-form-item label="人设">
-          <n-input v-model:value="form.persona" type="textarea" :rows="6" placeholder="描述该员工的身份、语气与工作原则…" />
+          <n-input v-model:value="form.persona" type="textarea" :rows="4" placeholder="描述该员工的身份、语气与工作原则…" />
         </n-form-item>
       </n-form>
-
-      <!-- 多选组 -->
-      <div class="groups">
-        <div v-for="g in groupDefs" :key="g.key" class="group">
-          <div class="group-title">{{ g.label }}</div>
-          <div class="chips">
-            <span v-if="!groupItems(g).length" class="hint-text">（暂无可选项）</span>
-            <label
-              v-for="it in groupItems(g)" :key="it.id"
-              class="chip"
-              :class="{ on: selected[g.key].has(it.id) }"
-            >
-              <input type="checkbox" :checked="selected[g.key].has(it.id)" @change="toggleChip(g.key, it.id, $event)" />
-              <span>{{ it.name }}</span>
-              <span v-if="it.description || g.key === 'knowledge_bases'" class="chip-desc">
-                <template v-if="g.key === 'knowledge_bases'">{{ it.ragflow_dataset_id || it.id }}{{ it.document_count != null ? ' · ' + it.document_count + ' 文档' : '' }}</template>
-                <template v-else>{{ it.description }}</template>
-              </span>
-            </label>
-          </div>
+      <template #footer>
+        <div class="modal-footer">
+          <n-button @click="showNew = false">取消</n-button>
+          <n-button type="primary" :loading="creating" @click="createEmp">创建并配置</n-button>
         </div>
-        <div class="hint-text">提示：勾选「start_refund」工具会自动启用人工审批；知识库直接绑定 RAGFlow 数据集，勾选后该员工的 kb_search 只检索所选数据集，不勾选时按 RAGFLOW_DATASET_IDS（或全部数据集）检索。</div>
-      </div>
-
-      <div class="actions">
-        <n-button type="primary" @click="saveEmp">保存</n-button>
-        <n-button v-if="current" type="error" ghost @click="delEmp">删除该员工</n-button>
-      </div>
-    </div>
+      </template>
+    </n-modal>
   </div>
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
-import { useDialog, useMessage } from 'naive-ui'
+import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMessage } from 'naive-ui'
 import api from '../api.js'
 
 defineOptions({ name: 'AdminView' })
 
-const dialog = useDialog()
+const router = useRouter()
 const message = useMessage()
 
 const backendOptions = [
   { label: 'state（默认，标准工具后端）', value: 'state' },
   { label: 'local_shell（数据分析沙箱）', value: 'local_shell' },
 ]
-const groupDefs = [
-  { key: 'skills', label: '技能 Skills' },
-  { key: 'tools', label: '工具 Tools' },
-  { key: 'knowledge_bases', label: '知识库 RAGFlow Datasets' },
-  { key: 'sops', label: 'SOP 流程文档' },
-  { key: 'connectors', label: '连接器 Connectors（MCP）' },
-]
 
-const catalog = ref({})
-const ragflowDatasets = ref([])
 const employees = ref([])
-const current = ref(null)
-const form = reactive({ name: '', role: '', model: 'openai:deepseek-v4-flash', backend: 'state', persona: '' })
-const selected = reactive({
-  skills: new Set(), tools: new Set(), knowledge_bases: new Set(),
-  sops: new Set(), connectors: new Set(),
-})
+const loading = ref(false)
+const showNew = ref(false)
+const creating = ref(false)
+const form = reactive({ name: '', role: '', model: '', backend: 'state', persona: '' })
 
-function toggleChip(key, id, e) {
-  if (e.target.checked) selected[key].add(id)
-  else selected[key].delete(id)
-}
-
-const kbOptions = computed(() => {
-  const datasets = ragflowDatasets.value || []
-  if (datasets.length) {
-    return datasets.map(d => ({
-      id: d.id,
-      name: d.name || d.id,
-      description: d.description || '',
-      ragflow_dataset_id: d.id,
-      document_count: d.document_count,
-    }))
-  }
-  return (catalog.value.knowledge_bases || []).filter(kb => kb.ragflow_dataset_id)
-})
-
-function groupItems(g) {
-  return g.key === 'knowledge_bases' ? kbOptions.value : (catalog.value[g.key] || [])
-}
-
-function clearForm() {
-  current.value = null
-  form.name = ''; form.role = ''; form.model = 'openai:deepseek-v4-flash'; form.backend = 'state'; form.persona = ''
-  Object.keys(selected).forEach(k => selected[k].clear())
-}
-
-function loadEmp(id) {
-  const e = employees.value.find(x => x.id === id)
-  if (!e) return
-  current.value = e
-  form.name = e.name || ''; form.role = e.role || ''; form.model = e.model || ''
-  form.backend = e.backend || 'state'; form.persona = e.persona || ''
-  selected.skills = new Set(e.skills || [])
-  selected.tools = new Set(e.tools || [])
-  const kbIds = new Set(kbOptions.value.map(k => k.id))
-  selected.knowledge_bases = new Set((e.kbs || []).filter(id => kbIds.has(id)))
-  selected.sops = new Set(e.sops || [])
-  selected.connectors = new Set(e.connectors || [])
-}
-
-function newEmp() { clearForm() }
-
-async function saveEmp() {
-  if (!form.name) { message.warning('请填写名称'); return }
-  const data = {
-    name: form.name.trim(), role: form.role.trim(), model: form.model.trim(),
-    backend: form.backend, persona: form.persona,
-    skills: [...selected.skills], tools: [...selected.tools], kbs: [...selected.knowledge_bases],
-    sops: [...selected.sops], connectors: [...selected.connectors],
-  }
-  try {
-    if (current.value) {
-      const { data: d } = await api.put(`/admin/employees/${current.value.id}`, data)
-      if (d.error) { message.error('保存失败：' + d.error); return }
-      message.success('已更新')
-    } else {
-      const { data: d } = await api.post('/admin/employees', data)
-      if (d.error) { message.error('保存失败：' + d.error); return }
-      message.success('已创建：' + d.id)
-    }
-    await reload()
-    if (!current.value && employees.value.length) loadEmp(employees.value[employees.value.length - 1].id)
-  } catch (e) { message.error('保存出错：' + e.message) }
-}
-
-function delEmp() {
-  if (!current.value) return
-  dialog.warning({
-    title: '删除员工',
-    content: `确认删除员工「${current.value.name}」？该操作不可恢复。`,
-    positiveText: '删除', negativeText: '取消',
-    onPositiveClick: async () => {
-      try {
-        await api.delete(`/admin/employees/${current.value.id}`)
-        message.success('已删除')
-        await reload()
-        clearForm()
-      } catch (e) { message.error('删除出错：' + e.message) }
-    },
-  })
+function openNew() {
+  Object.assign(form, { name: '', role: '', model: '', backend: 'state', persona: '' })
+  showNew.value = true
 }
 
 async function reload() {
+  loading.value = true
   try {
-    const [catRes, empRes, rfRes] = await Promise.all([
-      api.get('/admin/catalog'),
+    const [empRes, defRes] = await Promise.all([
       api.get('/admin/employees'),
-      api.get('/admin/ragflow/datasets').catch(() => ({ data: { datasets: [] } })),
+      api.get('/admin/defaults').catch(() => ({ data: {} })),
     ])
-    catalog.value = catRes.data
-    ragflowDatasets.value = rfRes.data?.datasets || []
     employees.value = (empRes.data || []).filter(x => x && !x.error)
-    if (current.value) {
-      const found = employees.value.find(x => x.id === current.value.id)
-      if (found) loadEmp(found.id)
-    }
-  } catch {}
+    if (!form.model && defRes.data?.model) form.model = defRes.data.model
+  } catch (e) {
+    message.error('加载员工列表失败：' + e.message)
+  } finally {
+    loading.value = false
+  }
 }
 
-onMounted(async () => {
-  await reload()
-  if (!current.value && employees.value.length) loadEmp(employees.value[0].id)
-})
+function goDetail(id) {
+  router.push(`/app/admin/employee/${id}`)
+}
+
+async function createEmp() {
+  if (!form.name.trim()) { message.warning('请填写名称'); return }
+  creating.value = true
+  try {
+    const { data } = await api.post('/admin/employees', {
+      name: form.name.trim(), role: form.role.trim(), model: form.model.trim(),
+      backend: form.backend, persona: form.persona,
+    })
+    if (data.error) { message.error('创建失败：' + data.error); return }
+    message.success('已创建：' + data.id)
+    showNew.value = false
+    goDetail(data.id)
+  } catch (e) {
+    message.error('创建出错：' + e.message)
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(reload)
 </script>
 
 <style scoped>
-.admin-layout { display: flex; height: 100%; }
-.emp-list-panel { width: 248px; border-right: 1px solid #e2e8f0; display: flex; flex-direction: column; background: #fff; }
-.list-head { padding: 12px 14px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #f1f5f9; }
-.list-title { font-size: 13px; font-weight: 600; color: #334155; }
-.list-body { flex: 1; overflow-y: auto; padding: 8px; }
-.list-empty { font-size: 12px; color: #94a3b8; padding: 18px 10px; text-align: center; }
-.emp-item { padding: 10px 12px; border-radius: 8px; cursor: pointer; margin-bottom: 4px; border: 1px solid transparent; transition: background 0.15s; }
-.emp-item:hover { background: #f1f5f9; }
-.emp-item.active { background: #eff6ff; border-color: #3b82f6; }
-.emp-name { font-size: 14px; font-weight: 500; color: #0f172a; }
-.emp-role { font-size: 11px; color: #64748b; margin-top: 2px; }
-
-.form-panel { flex: 1; overflow-y: auto; padding: 24px 28px; }
-.groups { margin-top: 20px; border-top: 1px solid #e2e8f0; padding-top: 18px; max-width: 860px; }
-.group { margin-bottom: 18px; }
-.group-title { font-size: 14px; font-weight: 600; color: #334155; margin-bottom: 10px; }
-.chips { display: flex; flex-wrap: wrap; gap: 8px; }
-.chip { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; padding: 6px 12px; border: 1px solid #cbd5e1; border-radius: 20px; background: #fff; cursor: pointer; user-select: none; transition: all 0.15s; }
-.chip input { display: none; }
-.chip.on { background: #eff6ff; border-color: #3b82f6; color: #2563eb; }
-.chip-desc { color: #94a3b8; font-size: 11px; }
-.hint-text { font-size: 12px; color: #94a3b8; margin-top: 8px; line-height: 1.6; }
-.actions { margin-top: 24px; display: flex; gap: 10px; max-width: 860px; }
+.emp-list-page { height: 100%; overflow-y: auto; padding: 24px 28px; }
+.page-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
+.page-title { font-size: 18px; font-weight: 600; color: #0f172a; }
+.page-sub { font-size: 12px; color: #94a3b8; margin-top: 4px; }
+.page-empty { color: #94a3b8; font-size: 13px; padding: 60px 0; text-align: center; }
+.cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+.emp-card { background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; cursor: pointer; transition: all 0.15s; }
+.emp-card:hover { border-color: #3b82f6; box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1); }
+.card-top { display: flex; align-items: center; gap: 10px; }
+.avatar { width: 40px; height: 40px; border-radius: 50%; background: #eff6ff; color: #2563eb; display: flex; align-items: center; justify-content: center; font-size: 17px; font-weight: 600; flex-shrink: 0; }
+.card-title { flex: 1; min-width: 0; }
+.name { font-size: 15px; font-weight: 600; color: #0f172a; }
+.role { font-size: 12px; color: #64748b; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.backend-tag { font-size: 11px; color: #7c3aed; background: #f5f3ff; border-radius: 10px; padding: 2px 8px; flex-shrink: 0; }
+.model { font-size: 12px; color: #64748b; margin-top: 10px; font-family: ui-monospace, monospace; }
+.stats { display: flex; flex-wrap: wrap; gap: 4px 12px; margin-top: 10px; font-size: 12px; color: #94a3b8; }
+.card-enter { font-size: 12px; color: #3b82f6; margin-top: 12px; opacity: 0; transition: opacity 0.15s; }
+.emp-card:hover .card-enter { opacity: 1; }
+.modal-footer { display: flex; justify-content: flex-end; gap: 10px; }
 </style>

--- a/frontend/src/views/employee/BasicInfoPage.vue
+++ b/frontend/src/views/employee/BasicInfoPage.vue
@@ -1,0 +1,96 @@
+<!-- 员工详情 · 基础信息页：名称/角色/模型/运行后端/人设编辑与删除员工 -->
+<template>
+  <div class="basic-page">
+    <n-form label-placement="left" :label-width="100" size="small" class="basic-form">
+      <n-form-item label="员工 ID">
+        <n-input :value="employee?.id || ''" readonly />
+      </n-form-item>
+      <n-form-item label="名称 *" required>
+        <n-input v-model:value="form.name" placeholder="如：小苏" />
+      </n-form-item>
+      <n-form-item label="角色">
+        <n-input v-model:value="form.role" placeholder="如：售前售后客服" />
+      </n-form-item>
+      <n-form-item label="模型">
+        <n-input v-model:value="form.model" placeholder="openai:deepseek-v4-flash" />
+      </n-form-item>
+      <n-form-item label="运行后端">
+        <n-select v-model:value="form.backend" :options="backendOptions" />
+      </n-form-item>
+      <n-form-item label="人设">
+        <n-input v-model:value="form.persona" type="textarea" :rows="8" placeholder="描述该员工的身份、语气与工作原则…" />
+      </n-form-item>
+    </n-form>
+    <div class="actions">
+      <n-button type="primary" :loading="saving" @click="save">保存</n-button>
+      <n-popconfirm @positive-click="delEmp">
+        <template #trigger>
+          <n-button type="error" ghost>删除该员工</n-button>
+        </template>
+        确认删除员工「{{ employee?.name }}」？该操作不可恢复。
+      </n-popconfirm>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useMessage } from 'naive-ui'
+import api from '../../api.js'
+
+defineOptions({ name: 'BasicInfoPage' })
+
+const props = defineProps({ employee: Object })
+const emit = defineEmits(['changed'])
+
+const router = useRouter()
+const message = useMessage()
+
+const backendOptions = [
+  { label: 'state（默认，标准工具后端）', value: 'state' },
+  { label: 'local_shell（数据分析沙箱）', value: 'local_shell' },
+]
+
+const form = reactive({ name: '', role: '', model: '', backend: 'state', persona: '' })
+const saving = ref(false)
+
+watch(() => props.employee, (e) => {
+  if (!e) return
+  form.name = e.name || ''; form.role = e.role || ''; form.model = e.model || ''
+  form.backend = e.backend || 'state'; form.persona = e.persona || ''
+}, { immediate: true })
+
+async function save() {
+  if (!form.name.trim()) { message.warning('请填写名称'); return }
+  saving.value = true
+  try {
+    const { data } = await api.put(`/admin/employees/${props.employee.id}`, {
+      name: form.name.trim(), role: form.role.trim(), model: form.model.trim(),
+      backend: form.backend, persona: form.persona,
+    })
+    if (data.error) { message.error('保存失败：' + data.error); return }
+    message.success('已更新')
+    emit('changed')
+  } catch (e) {
+    message.error('保存出错：' + e.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function delEmp() {
+  try {
+    await api.delete(`/admin/employees/${props.employee.id}`)
+    message.success('已删除')
+    router.push('/app/admin')
+  } catch (e) {
+    message.error('删除出错：' + e.message)
+  }
+}
+</script>
+
+<style scoped>
+.basic-page { max-width: 720px; }
+.actions { margin-top: 20px; display: flex; gap: 10px; }
+</style>

--- a/frontend/src/views/employee/ConnectorsPage.vue
+++ b/frontend/src/views/employee/ConnectorsPage.vue
@@ -1,0 +1,163 @@
+<!-- 员工详情 · 连接器选择页（差异化展示）：MCP 连接器卡片（transport 类型 / 命令或 URL /
+     参数预览），点卡片切换选中，独立保存。连接器的增删改在「资源中心」进行。 -->
+<template>
+  <div class="conn-page">
+    <div class="page-head">
+      <div>
+        <div class="page-title">连接器 Connectors（MCP）<span class="count">已选 {{ selectedSet.size }} / {{ items.length }}</span></div>
+        <div class="page-hint">勾选后该员工编译时接入对应 MCP server 的工具；连接器的创建与配置在「资源中心」进行。</div>
+      </div>
+      <n-input v-model:value="keyword" size="small" clearable placeholder="搜索…" style="width: 180px" />
+    </div>
+
+    <div v-if="loading" class="page-empty">加载中…</div>
+    <div v-else-if="!filtered.length" class="page-empty">{{ keyword ? '无匹配项' : '暂无可选连接器' }}</div>
+    <div v-else class="conn-cards">
+      <div
+        v-for="it in filtered" :key="it.id"
+        class="conn-card" :class="{ on: selectedSet.has(it.id) }"
+        @click="toggle(it.id)"
+      >
+        <div class="conn-check">{{ selectedSet.has(it.id) ? '✓' : '' }}</div>
+        <div class="conn-body">
+          <div class="conn-name">
+            {{ it.name }}
+            <span class="transport-tag" :class="it.transport">{{ transportLabel(it) }}</span>
+          </div>
+          <div class="conn-desc">{{ it.description || '无描述' }}</div>
+          <div v-if="it.endpoint" class="conn-endpoint" :title="it.endpoint">{{ it.endpoint }}</div>
+          <div v-if="it.toolCount != null" class="conn-tools">提供 {{ it.toolCount }} 个工具</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="page-foot">
+      <n-button type="primary" size="small" :loading="saving" :disabled="!dirty" @click="save">
+        保存{{ dirty ? '（有未保存修改）' : '' }}
+      </n-button>
+      <n-button v-if="dirty" size="small" quaternary @click="reset">还原</n-button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useMessage } from 'naive-ui'
+import api from '../../api.js'
+
+defineOptions({ name: 'ConnectorsPage' })
+
+const props = defineProps({ employee: Object })
+const emit = defineEmits(['changed'])
+
+const message = useMessage()
+const keyword = ref('')
+const loading = ref(false)
+const saving = ref(false)
+const items = ref([])
+const selectedSet = ref(new Set())
+
+const initialIds = computed(() => new Set(props.employee?.connectors || []))
+const dirty = computed(() =>
+  selectedSet.value.size !== initialIds.value.size ||
+  [...selectedSet.value].some(id => !initialIds.value.has(id)))
+
+watch(() => props.employee, () => reset(), { immediate: true })
+function reset() { selectedSet.value = new Set(props.employee?.connectors || []) }
+
+const filtered = computed(() => {
+  const kw = keyword.value.trim().toLowerCase()
+  if (!kw) return items.value
+  return items.value.filter(it =>
+    (it.name || '').toLowerCase().includes(kw) ||
+    (it.description || '').toLowerCase().includes(kw) ||
+    (it.endpoint || '').toLowerCase().includes(kw))
+})
+
+function toggle(id) {
+  const s = new Set(selectedSet.value)
+  if (s.has(id)) s.delete(id)
+  else s.add(id)
+  selectedSet.value = s
+}
+
+function transportLabel(it) {
+  return { stdio: 'stdio', http: 'HTTP', streamable: 'HTTP' }[it.transport] || it.transport
+}
+
+// 从连接器 config JSON 解析 transport 与可读的接入端信息
+function parseConfig(c) {
+  const cfg = c.config || {}
+  if (cfg.url) {
+    return { transport: cfg.transport || 'http', endpoint: cfg.url }
+  }
+  if (cfg.command) {
+    const args = (cfg.args || []).join(' ')
+    const cwd = cfg.cwd ? ` (cwd: ${cfg.cwd})` : ''
+    return { transport: 'stdio', endpoint: `${cfg.command} ${args}${cwd}`.trim() }
+  }
+  return { transport: 'unknown', endpoint: '' }
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const { data } = await api.get('/admin/catalog')
+    const cons = data.connectors || []
+    // 并发拉取各连接器详情（连接器数量少）；失败的单个降级为仅名称描述
+    const detailed = await Promise.all(cons.map(async (c) => {
+      try {
+        const r = await api.get(`/admin/connectors/${c.id}`)
+        if (r.data?.error) return { ...c, transport: 'unknown', endpoint: '' }
+        return { ...c, ...parseConfig(r.data) }
+      } catch {
+        return { ...c, transport: 'unknown', endpoint: '' }
+      }
+    }))
+    items.value = detailed
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const { data } = await api.put(`/admin/employees/${props.employee.id}`, {
+      connectors: [...selectedSet.value],
+    })
+    if (data.error) { message.error('保存失败：' + data.error); return }
+    message.success('已保存')
+    emit('changed')
+  } catch (e) {
+    message.error('保存出错：' + e.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.conn-page { max-width: 900px; }
+.page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
+.page-title { font-size: 14px; font-weight: 600; color: #334155; }
+.count { font-size: 12px; font-weight: 400; color: #94a3b8; margin-left: 10px; }
+.page-hint { font-size: 12px; color: #94a3b8; margin-top: 4px; line-height: 1.6; max-width: 560px; }
+.page-empty { font-size: 13px; color: #94a3b8; padding: 32px 0; text-align: center; background: #fafbfc; border-radius: 8px; }
+.conn-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+.conn-card { display: flex; gap: 10px; padding: 14px; border: 1px solid #e2e8f0; border-radius: 10px; background: #fff; cursor: pointer; transition: all 0.15s; }
+.conn-card:hover { border-color: #93c5fd; }
+.conn-card.on { border-color: #3b82f6; background: #eff6ff; }
+.conn-check { width: 18px; height: 18px; border-radius: 50%; border: 1px solid #cbd5e1; color: #fff; font-size: 11px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 2px; }
+.conn-card.on .conn-check { background: #3b82f6; border-color: #3b82f6; }
+.conn-body { flex: 1; min-width: 0; }
+.conn-name { font-size: 13px; font-weight: 600; color: #0f172a; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.transport-tag { font-size: 10px; padding: 1px 7px; border-radius: 8px; background: #f5f3ff; color: #7c3aed; font-weight: 400; }
+.transport-tag.stdio { background: #f1f5f9; color: #475569; }
+.conn-desc { font-size: 12px; color: #64748b; margin-top: 4px; line-height: 1.5; }
+.conn-endpoint { font-size: 11px; color: #94a3b8; font-family: ui-monospace, monospace; margin-top: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.conn-tools { font-size: 11px; color: #0e7490; margin-top: 4px; }
+.page-foot { margin-top: 14px; display: flex; gap: 8px; }
+</style>

--- a/frontend/src/views/employee/EmployeeDetailView.vue
+++ b/frontend/src/views/employee/EmployeeDetailView.vue
@@ -1,0 +1,101 @@
+<!-- 员工详情页：头部信息条 + 配置导航（各配置类型为独立子路由页，可直达/收藏）。
+     子页通过 router-view 渲染，保存后 emit changed 触发本页刷新。 -->
+<template>
+  <div class="emp-detail">
+    <div v-if="loading" class="detail-empty">加载中…</div>
+    <div v-else-if="!emp" class="detail-empty">员工不存在，<a @click="$router.push('/app/admin')">返回列表</a></div>
+    <template v-else>
+      <div class="detail-head">
+        <n-button text size="small" @click="$router.push('/app/admin')">← 返回列表</n-button>
+        <div class="head-main">
+          <div class="avatar">{{ (emp.name || '?').slice(0, 1) }}</div>
+          <div class="head-info">
+            <div class="name">
+              {{ emp.name }}
+              <span class="emp-id">{{ emp.id }}</span>
+            </div>
+            <div class="meta">{{ emp.role || '未设置角色' }} · {{ emp.model || '未设置模型' }} · {{ emp.backend || 'state' }}</div>
+          </div>
+        </div>
+      </div>
+      <n-tabs :value="activeTab" type="line" size="small" @update:value="goTab">
+        <n-tab v-for="t in tabs" :key="t.key" :name="t.key" :tab="tabLabel(t)" />
+      </n-tabs>
+      <div class="tab-body">
+        <router-view :employee="emp" @changed="reload" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useMessage } from 'naive-ui'
+import api from '../../api.js'
+
+defineOptions({ name: 'EmployeeDetailView' })
+
+const route = useRoute()
+const router = useRouter()
+const message = useMessage()
+
+const emp = ref(null)
+const loading = ref(false)
+
+const tabs = [
+  { key: '', label: '基础信息', countKey: null },
+  { key: 'skills', label: '技能', countKey: 'skills' },
+  { key: 'tools', label: '工具', countKey: 'tools' },
+  { key: 'knowledge-bases', label: '知识库', countKey: 'kbs' },
+  { key: 'sops', label: 'SOP', countKey: 'sops' },
+  { key: 'connectors', label: '连接器', countKey: 'connectors' },
+]
+
+const activeTab = computed(() => {
+  // 子路径 '' → ''，'skills' → 'skills'，'knowledge-bases' → 'knowledge-bases'
+  const rest = route.path.split('/app/admin/employee/')[1] || ''
+  const idLen = (route.params.id || '').length
+  const sub = rest.slice(idLen + 1)
+  return sub
+})
+
+function tabLabel(t) {
+  if (!t.countKey) return t.label
+  const n = (emp.value?.[t.countKey] || []).length
+  return `${t.label} ${n}`
+}
+
+function goTab(key) {
+  const base = `/app/admin/employee/${route.params.id}`
+  router.push(key ? `${base}/${key}` : base)
+}
+
+async function reload() {
+  loading.value = true
+  try {
+    const { data } = await api.get(`/admin/employees/${route.params.id}`)
+    emp.value = data?.error ? null : data
+  } catch (e) {
+    message.error('加载员工失败：' + e.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => route.params.id, reload, { immediate: true })
+</script>
+
+<style scoped>
+.emp-detail { height: 100%; display: flex; flex-direction: column; padding: 18px 28px 0; }
+.detail-empty { color: #94a3b8; font-size: 13px; padding: 60px 0; text-align: center; }
+.detail-empty a { color: #3b82f6; cursor: pointer; }
+.detail-head { margin-bottom: 12px; }
+.head-main { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+.avatar { width: 46px; height: 46px; border-radius: 50%; background: #eff6ff; color: #2563eb; display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 600; flex-shrink: 0; }
+.head-info { min-width: 0; }
+.name { font-size: 17px; font-weight: 600; color: #0f172a; display: flex; align-items: center; gap: 8px; }
+.emp-id { font-size: 11px; color: #94a3b8; font-family: ui-monospace, monospace; font-weight: 400; }
+.meta { font-size: 12px; color: #64748b; margin-top: 3px; }
+.tab-body { flex: 1; overflow-y: auto; padding: 16px 2px 24px; }
+</style>

--- a/frontend/src/views/employee/KnowledgeBasesPage.vue
+++ b/frontend/src/views/employee/KnowledgeBasesPage.vue
@@ -1,0 +1,146 @@
+<!-- 员工详情 · 知识库选择页（差异化展示）：RAGFlow 数据集卡片（文档数 / dataset id /
+     描述），点卡片切换选中，独立保存。 -->
+<template>
+  <div class="kb-page">
+    <div class="page-head">
+      <div>
+        <div class="page-title">知识库 RAGFlow Datasets<span class="count">已选 {{ selectedSet.size }} / {{ items.length }}</span></div>
+        <div class="page-hint">勾选后该员工的 kb_search 只检索所选数据集；不勾选时按 RAGFLOW_DATASET_IDS（或全部数据集）检索。数据集在 RAGFlow 侧维护。</div>
+      </div>
+      <n-input v-model:value="keyword" size="small" clearable placeholder="搜索…" style="width: 180px" />
+    </div>
+
+    <div v-if="loading" class="page-empty">加载中…</div>
+    <div v-else-if="!filtered.length" class="page-empty">{{ keyword ? '无匹配项' : '暂无可选数据集（检查 RAGFlow 连接）' }}</div>
+    <div v-else class="kb-cards">
+      <div
+        v-for="it in filtered" :key="it.id"
+        class="kb-card" :class="{ on: selectedSet.has(it.id) }"
+        @click="toggle(it.id)"
+      >
+        <div class="kb-check">{{ selectedSet.has(it.id) ? '✓' : '' }}</div>
+        <div class="kb-body">
+          <div class="kb-name">{{ it.name }}</div>
+          <div class="kb-desc">{{ it.description || '无描述' }}</div>
+          <div class="kb-meta">
+            <span class="doc-count">{{ it.document_count != null ? it.document_count + ' 文档' : '文档数未知' }}</span>
+            <span class="dataset-id">{{ it.ragflow_dataset_id || it.id }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="page-foot">
+      <n-button type="primary" size="small" :loading="saving" :disabled="!dirty" @click="save">
+        保存{{ dirty ? '（有未保存修改）' : '' }}
+      </n-button>
+      <n-button v-if="dirty" size="small" quaternary @click="reset">还原</n-button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useMessage } from 'naive-ui'
+import api from '../../api.js'
+
+defineOptions({ name: 'KnowledgeBasesPage' })
+
+const props = defineProps({ employee: Object })
+const emit = defineEmits(['changed'])
+
+const message = useMessage()
+const keyword = ref('')
+const loading = ref(false)
+const saving = ref(false)
+const items = ref([])
+const selectedSet = ref(new Set())
+
+const initialIds = computed(() => new Set(props.employee?.kbs || []))
+const dirty = computed(() =>
+  selectedSet.value.size !== initialIds.value.size ||
+  [...selectedSet.value].some(id => !initialIds.value.has(id)))
+
+watch(() => props.employee, () => reset(), { immediate: true })
+function reset() { selectedSet.value = new Set(props.employee?.kbs || []) }
+
+const filtered = computed(() => {
+  const kw = keyword.value.trim().toLowerCase()
+  if (!kw) return items.value
+  return items.value.filter(it =>
+    (it.name || '').toLowerCase().includes(kw) ||
+    (it.description || '').toLowerCase().includes(kw) ||
+    (it.ragflow_dataset_id || '').includes(kw))
+})
+
+function toggle(id) {
+  const s = new Set(selectedSet.value)
+  if (s.has(id)) s.delete(id)
+  else s.add(id)
+  selectedSet.value = s
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [rfRes, catRes] = await Promise.all([
+      api.get('/admin/ragflow/datasets').catch(() => ({ data: { datasets: [] } })),
+      api.get('/admin/catalog'),
+    ])
+    const datasets = rfRes.data?.datasets || []
+    if (datasets.length) {
+      items.value = datasets.map(d => ({
+        id: d.id, name: d.name || d.id, description: d.description || '',
+        ragflow_dataset_id: d.id, document_count: d.document_count,
+      }))
+    } else {
+      // RAGFlow 不可达时回退到 catalog 已登记的知识库
+      items.value = (catRes.data?.knowledge_bases || [])
+        .filter(kb => kb.ragflow_dataset_id)
+        .map(kb => ({ ...kb, document_count: null }))
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const { data } = await api.put(`/admin/employees/${props.employee.id}`, {
+      kbs: [...selectedSet.value],
+    })
+    if (data.error) { message.error('保存失败：' + data.error); return }
+    message.success('已保存')
+    emit('changed')
+  } catch (e) {
+    message.error('保存出错：' + e.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.kb-page { max-width: 900px; }
+.page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
+.page-title { font-size: 14px; font-weight: 600; color: #334155; }
+.count { font-size: 12px; font-weight: 400; color: #94a3b8; margin-left: 10px; }
+.page-hint { font-size: 12px; color: #94a3b8; margin-top: 4px; line-height: 1.6; max-width: 560px; }
+.page-empty { font-size: 13px; color: #94a3b8; padding: 32px 0; text-align: center; background: #fafbfc; border-radius: 8px; }
+.kb-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+.kb-card { position: relative; display: flex; gap: 10px; padding: 14px; border: 1px solid #e2e8f0; border-radius: 10px; background: #fff; cursor: pointer; transition: all 0.15s; }
+.kb-card:hover { border-color: #93c5fd; }
+.kb-card.on { border-color: #3b82f6; background: #eff6ff; }
+.kb-check { width: 18px; height: 18px; border-radius: 50%; border: 1px solid #cbd5e1; color: #fff; font-size: 11px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 2px; }
+.kb-card.on .kb-check { background: #3b82f6; border-color: #3b82f6; }
+.kb-body { flex: 1; min-width: 0; }
+.kb-name { font-size: 13px; font-weight: 600; color: #0f172a; }
+.kb-desc { font-size: 12px; color: #64748b; margin-top: 4px; line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; min-height: 36px; }
+.kb-meta { display: flex; align-items: center; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.doc-count { font-size: 11px; color: #0e7490; background: #ecfeff; border-radius: 8px; padding: 1px 8px; }
+.dataset-id { font-size: 10px; color: #94a3b8; font-family: ui-monospace, monospace; }
+.page-foot { margin-top: 14px; display: flex; gap: 8px; }
+</style>

--- a/frontend/src/views/employee/SkillsPage.vue
+++ b/frontend/src/views/employee/SkillsPage.vue
@@ -1,0 +1,28 @@
+<!-- 员工详情 · 技能选择页：勾选该员工可用的技能（SKILL.md 规程，运行时 read_file 查阅） -->
+<template>
+  <ResourcePicker
+    :employee="employee" field-key="skills" title="技能 Skills"
+    hint="勾选后该员工运行时可查阅对应 SKILL.md 规程；技能编辑在「资源中心」进行。"
+    :items="items" @changed="$emit('changed')"
+  />
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../../api.js'
+import ResourcePicker from '../../components/employee/ResourcePicker.vue'
+
+defineOptions({ name: 'SkillsPage' })
+defineProps({ employee: Object })
+defineEmits(['changed'])
+
+const items = ref([])
+
+onMounted(async () => {
+  const { data } = await api.get('/admin/catalog')
+  items.value = (data.skills || []).map(s => ({
+    id: s.id, name: s.name, description: s.description,
+    tags: s.is_custom ? [{ label: '自定义' }] : [],
+  }))
+})
+</script>

--- a/frontend/src/views/employee/SopsPage.vue
+++ b/frontend/src/views/employee/SopsPage.vue
@@ -1,0 +1,32 @@
+<!-- 员工详情 · SOP 选择页：勾选该员工遵循的 SOP 流程文档（可展开预览内容） -->
+<template>
+  <ResourcePicker
+    :employee="employee" field-key="sops" title="SOP 流程文档"
+    hint="勾选后 SOP 全文会同步进员工 Store，运行时 read_file 查阅；SOP 编辑在「资源中心」进行。"
+    :items="items" @changed="$emit('changed')"
+  />
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../../api.js'
+import ResourcePicker from '../../components/employee/ResourcePicker.vue'
+
+defineOptions({ name: 'SopsPage' })
+defineProps({ employee: Object })
+defineEmits(['changed'])
+
+const items = ref([])
+
+onMounted(async () => {
+  const { data } = await api.get('/admin/catalog')
+  items.value = (data.sops || []).map(s => {
+    const firstLine = (s.content || '').split('\n').find(l => l.trim()) || ''
+    return {
+      id: s.id, name: s.name,
+      description: firstLine.slice(0, 120) || s.description,
+      tags: s.content ? [{ label: `${s.content.length} 字` }] : [],
+    }
+  })
+})
+</script>

--- a/frontend/src/views/employee/ToolsPage.vue
+++ b/frontend/src/views/employee/ToolsPage.vue
@@ -1,0 +1,30 @@
+<!-- 员工详情 · 工具选择页：勾选该员工可用的原子工具（审批工具带提示） -->
+<template>
+  <ResourcePicker
+    :employee="employee" field-key="tools" title="工具 Tools"
+    hint="勾选「start_refund」等需审批工具会自动启用人工审批拦截；get_current_time 为全局工具，所有员工默认可用。"
+    :items="items" @changed="$emit('changed')"
+  />
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../../api.js'
+import ResourcePicker from '../../components/employee/ResourcePicker.vue'
+
+defineOptions({ name: 'ToolsPage' })
+defineProps({ employee: Object })
+defineEmits(['changed'])
+
+const items = ref([])
+
+onMounted(async () => {
+  const { data } = await api.get('/admin/catalog')
+  items.value = (data.tools || []).map(t => {
+    const tags = []
+    if (t.is_global) tags.push({ label: '全局默认', type: 'info' })
+    if (t.needs_approval) tags.push({ label: '需人工审批', type: 'warn' })
+    return { id: t.id, name: t.name, description: t.description, tags }
+  })
+})
+</script>

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -44,6 +44,33 @@ def test_employee_crud_and_interrupt_derivation():
     assert catalog.get_employee_config(eid) is None
 
 
+def test_employee_partial_update_keeps_other_fields():
+    """部分更新：只传某一资源类型/字段时，其余配置沿用现值不丢。"""
+    _seed_tool("kb_search")
+    eid = catalog.create_employee({
+        "name": "局部更新员", "role": "客服", "model": "openai:m", "backend": "state",
+        "persona": "原人设", "tools": ["kb_search"], "skills": [], "kbs": [],
+        "sops": [], "connectors": [],
+    })
+
+    # 只改连接器：名称/人设/工具等应保持不变
+    assert catalog.update_employee(eid, {"connectors": ["crm"]})
+    cfg = catalog.get_employee_config(eid)
+    assert cfg["connectors"] == ["crm"]
+    assert cfg["name"] == "局部更新员"
+    assert cfg["persona"] == "原人设"
+    assert cfg["tools"] == ["kb_search"]
+
+    # 只改名称：资源关联保持不变
+    assert catalog.update_employee(eid, {"name": "局部更新员2"})
+    cfg2 = catalog.get_employee_config(eid)
+    assert cfg2["name"] == "局部更新员2"
+    assert cfg2["connectors"] == ["crm"]
+    assert cfg2["tools"] == ["kb_search"]
+
+    catalog.delete_employee(eid)
+
+
 def test_backfill_employees_if_missing_adds_netops():
     """老库补种：net-ops 员工缺失时由 backfill 补回（含技能/工具/本体工具）。"""
     catalog.init()


### PR DESCRIPTION
## 变更说明

员工管理从「左列表 + 单页全量表单」重构为「列表入口 + 每类配置独立页面」：

- **员工列表页**（/app/admin）：卡片网格总览，每张卡片显示名称/角色/模型/后端 + 五类资源配额统计；「+ 新建员工」弹窗只填基础信息，创建后直接跳详情页继续配置
- **员工详情页**（/app/admin/employee/:id）：头部信息条 + tab 导航（基础信息/技能/工具/知识库/SOP/连接器，含已选数量），各配置页为独立子路由，可直达、可收藏、可分享
- **技能/工具/SOP 页**：复用新组件 ResourcePicker（搜索 / 全选清空 / 脏检查 / 还原 / 独立保存）
- **知识库页（差异化）**：RAGFlow 数据集卡片，展示文档数与 dataset id，RAGFlow 不可达时回退 catalog
- **连接器页（差异化）**：MCP 连接器卡片，展示 transport 类型（stdio/HTTP）与命令/URL 预览
- **后端**：update_employee 支持部分更新——payload 未出现的字段与资源关联沿用现值，各配置页保存互不覆盖

## 验证清单

- [x] `pytest tests/test_catalog.py` 9 项通过（新增部分更新回归测试）
- [x] `npx vite build` 通过
- [x] PG 活服务实测：PUT 单字段后其余配置（技能/工具/SOP/连接器/人设）完整保留
- [x] 浏览器冒烟：列表页 / 详情页 / 五个配置 tab 全部正常渲染