### PR TITLE
feat: 平台登录日志——登录/改密事件纳入审计

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,10 +1,10 @@
-"""认证路由：登录 / 改密 / 当前用户。"""
+"""认证路由：登录 / 改密 / 当前用户。登录成功、登录失败、自助改密均落审计日志。"""
 
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from app import auth, catalog
+from app import audit, auth, catalog
 from app.models import LoginIn, ChangePwdIn
 
 router = APIRouter(prefix="/api/auth")
@@ -31,15 +31,25 @@ async def login(body: LoginIn, request: Request):
     ip = request.client.host if request.client else "?"
     key = f"{ip}|{body.username}"
     if _login_throttled(key):
+        # 限流拒绝不写审计：底层失败已留痕，避免爆破流量放大审计表写入
         raise HTTPException(429, "尝试过于频繁，请 1 分钟后再试")
     u = catalog.get_user_by_username(body.username)
     if not u or not auth.verify_password(body.password, u["password_hash"]):
+        # 记录尝试的用户名（用户不存在时并无真实账号可归属）
+        audit.log("login_failed", "auth", body.username,
+                  admin={"id": "", "username": body.username}, request=request,
+                  after={"reason": "用户名或密码错误"})
         _login_record_fail(key)
         raise HTTPException(401, "用户名或密码错误")
     if u.get("status") != "active":
+        audit.log("login_failed", "auth", body.username,
+                  admin={"id": u["id"], "username": body.username}, request=request,
+                  after={"reason": "账号已禁用"})
         raise HTTPException(403, "账号已禁用")
     _LOGIN_FAILS.pop(key, None)
     token = auth.create_token(u)
+    audit.log("login", "auth", u["id"],
+              admin={"id": u["id"], "username": u["username"]}, request=request)
     return {"token": token,
             "must_change_password": bool(u.get("must_change_password")),
             "user": {"id": u["id"], "username": u["username"],
@@ -47,7 +57,8 @@ async def login(body: LoginIn, request: Request):
 
 
 @router.post("/change-password")
-async def change_password(body: ChangePwdIn, user: dict = Depends(auth.get_current_user)):
+async def change_password(body: ChangePwdIn, request: Request,
+                          user: dict = Depends(auth.get_current_user)):
     u = catalog.get_user_by_username(user["username"])
     if not u or not auth.verify_password(body.old_password, u["password_hash"]):
         raise HTTPException(401, "原密码错误")
@@ -56,6 +67,9 @@ async def change_password(body: ChangePwdIn, user: dict = Depends(auth.get_curre
     if body.new_password == body.old_password:
         raise HTTPException(400, "新密码不能与原密码相同")
     catalog.set_password(u["id"], auth.hash_password(body.new_password))
+    # 自助改密留痕（不记密码内容），obj_type 与 admin 重置密码一致
+    audit.log("update", "user_password", u["id"],
+              admin={"id": u["id"], "username": u["username"]}, request=request)
     return {"ok": True}
 
 

--- a/frontend/src/views/audit/AuditLogsPage.vue
+++ b/frontend/src/views/audit/AuditLogsPage.vue
@@ -73,13 +73,17 @@ const objOptions = [
   { label: '员工分配', value: 'assignment' },
   { label: '护栏配置', value: 'guard_settings' },
   { label: '敏感词', value: 'sensitive_word' },
+  { label: '登录/认证', value: 'auth' },
 ]
 const actionOptions = [
   { label: '新增', value: 'create' },
   { label: '修改', value: 'update' },
   { label: '删除', value: 'delete' },
+  { label: '登录成功', value: 'login' },
+  { label: '登录失败', value: 'login_failed' },
 ]
-const actionLabel = { create: '新增', update: '修改', delete: '删除' }
+const actionLabel = { create: '新增', update: '修改', delete: '删除',
+                      login: '登录成功', login_failed: '登录失败' }
 const objNameMap = Object.fromEntries(objOptions.map(o => [o.value, o.label]))
 
 function objLabel(l) {

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -122,6 +122,60 @@ def test_audit_after_is_full_state_snapshot(monkeypatch):
     assert set(before.keys()) == set(after.keys())
 
 
+def test_login_events_audited(monkeypatch):
+    """登录成功/失败、自助改密均落审计；限流拒绝不写审计。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app import auth as auth_mod
+    from app.routes.auth import router as auth_router
+
+    catalog.create_user("login_t", auth_mod.hash_password("secret123"),
+                        role="user", user_id="u_login_t")
+    app = FastAPI()
+    app.include_router(auth_router)
+    client = TestClient(app)
+
+    # 密码错误 → login_failed：obj_id/actor 为尝试的用户名，after 含原因
+    r = client.post("/api/auth/login",
+                    json={"username": "login_t", "password": "wrong-pass"})
+    assert r.status_code == 401
+    logs, _ = audit.list_logs(action="login_failed")
+    f = logs[0]
+    assert f["obj_id"] == "login_t" and f["actor_name"] == "login_t"
+    assert json.loads(f["after"])["reason"] == "用户名或密码错误"
+
+    # 登录成功 → login：actor 为真实用户
+    r = client.post("/api/auth/login",
+                    json={"username": "login_t", "password": "secret123"})
+    assert r.status_code == 200
+    ok = next(l for l in audit.list_logs(action="login")[0]
+              if l["obj_id"] == "u_login_t")
+    assert ok["actor_id"] == "u_login_t" and ok["ip"]
+
+    # 自助改密 → user_password 审计，不记密码内容
+    tok = r.json()["token"]
+    r = client.post("/api/auth/change-password",
+                    json={"old_password": "secret123", "new_password": "newpass456"},
+                    headers={"Authorization": f"Bearer {tok}"})
+    assert r.status_code == 200
+    pw_logs = [l for l in audit.list_logs(obj_type="user_password")[0]
+               if l["actor_id"] == "u_login_t"]
+    assert pw_logs
+    assert "newpass456" not in (pw_logs[0]["after"] or "")
+    assert "newpass456" not in (pw_logs[0]["before"] or "")
+
+    # 限流拒绝（5 次失败后）→ 不再新增审计写入，防爆破流量放大
+    from app.routes import auth as auth_routes
+    key = "testclient|login_t"
+    auth_routes._LOGIN_FAILS[key] = [__import__("time").time()] * 5
+    before_count = audit.list_logs(action="login_failed")[1]
+    r = client.post("/api/auth/login",
+                    json={"username": "login_t", "password": "x"})
+    assert r.status_code == 429
+    assert audit.list_logs(action="login_failed")[1] == before_count
+
+
 def test_audit_user_snapshot_excludes_password_hash(monkeypatch):
     """用户变更的审计快照不得包含 password_hash。"""
     from app import auth as auth_mod


### PR DESCRIPTION
## 变更内容

沿用 #17 建立的审计体系（audit_logs 表 + 查询端点 + 前端审计页），把认证事件纳入留痕：

### 后端（routes/auth.py）
- **登录成功**：action=login，记录用户、IP、时间
- **登录失败**：action=login_failed，记录**尝试的用户名**（用户不存在时并无真实账号可归属）、IP、失败原因（密码错误 / 账号已禁用）
- **自助改密**：obj_type=user_password（与 admin 重置密码一致），只记动作不记密码内容
- **限流拒绝（429）不写审计**：底层登录失败已留痕，避免爆破流量直接放大审计表写入

### 前端
- 审计日志页新增「登录/认证」对象类型筛选与「登录成功/登录失败」动作筛选

## 验证清单
- [x] tests/test_audit.py 新增登录事件用例：失败留痕含原因、成功 actor 为真实用户、改密留痕且不含密码内容、限流路径零写入
- [x] 全量 pytest 178 passed
- [x] npx vite build 通过