### PR TITLE
feat: 自动化任务平台——定时/事件触发自动执行，发布 v0.10.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ LOG_LEVEL=INFO
 # SQLite 数据目录；容器部署挂载卷后改为 /app/data。本地留空=项目根。
 # APP_DATA_DIR=/app/data
 # 版本号（/health 与日志会打印），便于多实例时定位。
-APP_VERSION=0.9.0
+APP_VERSION=0.10.0
 
 # ===== 数据库后端 =====
 # postgres（默认）：连接 PostgreSQL，每个业务库一个 database（catalog/conversations/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,202 +1,348 @@
 # Changelog
 
+## 0.10.0 (2026-09-04)
+
+### 重磅变更：数字员工从「被动问答」升级为「主动执行」——自动化任务平台
+
+- **补上机器触发这半边**：平台此前所有对话 run 均由人发消息发起，定时简报、到期提醒、预警维系这类高价值场景天然无法覆盖。本版新增「自动化任务」子系统：**定时（cron）/ 事件（webhook）两类触发源 → 自动起 run → 结果落会话（可选推送外部 IM）**，数字员工开始具备"到点主动干活、事件来了自动响应"的产品形态
+
+- **执行链路完全复用对话运行时**：自动 run 与人工对话走同一条 `_stream_run` 链路——敏感词护栏、工具调用护栏、长期记忆、Trace 全链路可观测、审批中断全部生效；每次触发的结果都是一条完整会话，在会话历史中可见、可回溯、可继续追问，而非黑盒日志
+
+- **三大典型场景开箱即用**：
+
+  - 每日经营简报——`0 9 * * 1-5` 定时让 xiaoshu 拉数出简报，结果推送到 IM 频道
+
+  - 合同/到期提醒——定时扫描本体数据，到期前自动生成维系建议
+
+  - 事件驱动处理——CRM 退款、监控告警等外部系统 webhook 一发，客服/运维员工立即产出处理方案（如需外发可接审批）
+
+### 新增
+
+- **定时任务（cron）**：`automations` 表 + 调度器随应用 lifespan 启动（30s 扫描周期）；`next_fire_at` CAS 抢占保证多实例/慢执行重入时同一触发点只执行一次；停机期间错过的触发点只补跑一次，不追历史风暴；`AUTOMATIONS_DISABLED=1` 可关闭
+
+- **事件触发（webhook）**：`POST /api/automations/events/{event_key}` 即时触发所有监听该事件的任务；任务级 secret 鉴权（未配置则放行）；事件数据 JSON 自动注入指令模板 `{{payload}}` 占位符（无占位符时附加尾部），`{{now}}` 注入当前时间；同步返回每个任务的执行结果（会话 ID + 完整回复）
+
+- **前端「自动任务」管理页**（admin，侧边栏）：任务列表（触发方式/员工/指令/上次运行状态与次数/失败原因提示）、启停开关、新建编辑弹窗（cron 快捷模板、事件调用地址展示、员工/频道下拉）、「立即运行」手动验收并直接查看 agent 回复
+
+- **结果推送**：任务可绑定 IM 频道，执行结果经频道 `outbound_webhook` 推送到企业微信/飞书等外部 IM；不绑定则静默落会话历史
+
+- **零新增依赖的 cron 解析器**：自实现 5 字段解析（支持 `*` `,` `-` `/`、`7=周日`、日/周同时受限取并集的标准语义），创建/编辑时校验表达式合法性并预排 `next_fire_at`
+
+- **回归测试 tests/test\_automations.py（19 条全通过）**：cron 匹配/next\_fire 计算/非法表达式/CAS 抢占防重/CRUD/启停重排期/模板渲染
+
+### 修复
+
+- traces 聚合 SQL 的 PostgreSQL 方言 bug：`SUM(etype='llm')` 布尔求和写法在 PG 报 `function sum(boolean) does not exist`，导致每次 run 的 llm\_calls/tool\_calls 统计回写失败、trace 卡在 running；改为 `SUM(CASE WHEN ... THEN 1 ELSE 0 END)`（SQLite/PG 双方言兼容）
+
+***
+
 ## 0.9.0 (2026-09-01)
 
 ### 重磅变更：新增「浙江联通售前客服」，移除旧演示客服 xiaosu
 
-- **新员工 unicom-presale（小联·浙江联通售前客服）**：售前咨询人设（资费/政策/流程必须先 kb_search 检索、禁止编造），绑定 RAGFlow「浙江联通业务知识库」，工具 kb_search + create_ticket
+- **新员工 unicom-presale（小联·浙江联通售前客服）**：售前咨询人设（资费/政策/流程必须先 kb\_search 检索、禁止编造），绑定 RAGFlow「浙江联通业务知识库」，工具 kb\_search + create\_ticket
+
 - **新技能 unicom-presale-faq**：浙江联通售前咨询规程（定位主题 → 检索 → 引用来源 → 给下一步建议）
+
 - **RAGFlow「浙江联通业务知识库」**：联网搜集整理的 11 个知识文档（5G 套餐、融合宽带、互联网卡、特色套餐、携号转网、合约变更、靓号、销户异地、话费积分、政企业务、增值国际业务），101 chunks，配套幂等灌入脚本 `scripts/seed_zj_unicom.py`
-- **移除 xiaosu（旧演示客服）**：员工 yaml、product-faq / complaint-handling 技能、sop_complaint 种子及 catalog 记录全部清理，历史会话数据保留；依赖真实种子员工的测试改用 unicom-presale
+
+- **移除 xiaosu（旧演示客服）**：员工 yaml、product-faq / complaint-handling 技能、sop\_complaint 种子及 catalog 记录全部清理，历史会话数据保留；依赖真实种子员工的测试改用 unicom-presale
 
 ### 变更
 
-- 调试端点（/api/debug/memory、runtime.dump_store）默认员工从 xiaosu 改为 unicom-presale
-- CONNECTOR_ASSIGN 中 crm 连接器指派移除 xiaosu；本体工具 backfill 名单加入 unicom-presale
+- 调试端点（/api/debug/memory、runtime.dump\_store）默认员工从 xiaosu 改为 unicom-presale
+
+- CONNECTOR\_ASSIGN 中 crm 连接器指派移除 xiaosu；本体工具 backfill 名单加入 unicom-presale
+
+***
 
 ## 0.8.0 (2026-08-30)
 
 ### 重磅变更：net-ops 从「单技能」升级为「算网运营专家」四能力架构
 
-- **net-ops 人设与能力完整升级**：角色改为「算网运营专家」，backend=local_shell，4 项核心技能 + 3 条算网专用 SOP 绑定；内置员工保持 6 个，但小网已从 1 个技能 → 4 技能满配
-  - **故障影响分析**：告警关联（netops_alerts.csv 按基站/时间窗/严重度统计）+ 本体多跳（基站 → cover 片区 → 客户 → 筛 VIP → 装维责任人 → 联系方式）
+- **net-ops 人设与能力完整升级**：角色改为「算网运营专家」，backend=local\_shell，4 项核心技能 + 3 条算网专用 SOP 绑定；内置员工保持 6 个，但小网已从 1 个技能 → 4 技能满配
+
+  - **故障影响分析**：告警关联（netops\_alerts.csv 按基站/时间窗/严重度统计）+ 本体多跳（基站 → cover 片区 → 客户 → 筛 VIP → 装维责任人 → 联系方式）
+
   - **运营指标分析**：趋势/环比/同比 + SLA 达标判定 + 异常日定位与告警归因（联动网元表定位具体故障场景）
-  - **资源容量分析**：算力 / 网络 / IDC 三类台账跑数 + 80% 预警/90% 紧急扩容阈值 + 目标 70% 扩容缺口公式 + 本体 deploy_in/backhaul 归属查询
-  - **SOP 路由与执行**：按场景路由到 cutover/emergency/escalation → 刚性步骤逐条执行 → create_ticket 登记工单 → /memories/ 沉淀处置经验
+
+  - **资源容量分析**：算力 / 网络 / IDC 三类台账跑数 + 80% 预警/90% 紧急扩容阈值 + 目标 70% 扩容缺口公式 + 本体 deploy\_in/backhaul 归属查询
+
+  - **SOP 路由与执行**：按场景路由到 cutover/emergency/escalation → 刚性步骤逐条执行 → create\_ticket 登记工单 → /memories/ 沉淀处置经验
 
 ### 新增
 
 - **三条算网 SOP 制度（catalog seeds + Store 接入）**：
-  - sop_netops_emergency 算网应急预案启动（5 步：影响面判定 → 分级 → 通知链 → VIP 保障 → 工单登记）
-  - sop_netops_cutover 网络割接操作规范（6 步：申请 → 影响评估 → 00:00-06:00 时间窗刚性 → 超 90 分钟强制回退 → 执行监控 → 完工）
-  - sop_netops_escalation 重大故障升级上报（5 步：P1 判定 → 15 分钟到值班长、30 分钟首次升级 → 升级链路 → 工单 → 跟进）
-- **老库幂等升级 backfill_netops_upgrade()**：三路径互不干扰——SOP 按 slug 幂等补缺；员工-技能/员工-SOP 绑定按 emp_id+skill_id(sop_id) 幂等补缺；persona/description 仅在"管理员未改动"的情况下才覆盖升级，保护自定义修改
-- **本体扩展：算网资源域**：新增实体类型 机房(datacenter)/算力节点(compute_node)/传输链路(link)，关系类型 部署于(deploy_in)/回传链路(backhaul)；种子播种 2 机房、4 算力节点、3 传输链路 + 4 条 deploy_in + 4 条 backhaul 关系，与本体已有基站/片区可直接组合多跳查询；函数 `seed_netops_resources_if_empty()` 幂等
-- **三份算网演示数据集 + 生成脚本**（scripts/generate_netops_data.py，固定随机种子可复现）：
-  - netops_alerts.csv：378 条告警（90 天），P1-P4 四档，埋三条故事线：城东 8/8-8/10 连续 P1 板卡故障、高新 2 号站近 30 天 P2 传输故障频发、周末突发故障
-  - netops_kpi.csv：181 天 × 3 片区的接通率/掉线率/SLA/满意度，KPI 与城东大障日同步跌落
-  - netops_resources.csv：12 条三类资源台账，GPU 训练节点 92.2% + 高新-下沙光缆 87.0% 命中预警
-- **专项回归测试 tests/test_netops_expert.py（10 条全通过）**：覆盖数据结构/故事线/yaml/触发条件/SOP 播种/backfill 双路径（空库/老库）/本体幂等；pytest 夹具 `tmp_db` 保证 SQLite 不碰真实数据
-- **E2E 手动验证脚本 scripts/verify_netops_e2e.py**：4 个典型问题 HTTP API 直跑（登录→改密→会话→SSE 流），自动核对工具调用与回答要点，便于改动后的冒烟
+
+  - sop\_netops\_emergency 算网应急预案启动（5 步：影响面判定 → 分级 → 通知链 → VIP 保障 → 工单登记）
+
+  - sop\_netops\_cutover 网络割接操作规范（6 步：申请 → 影响评估 → 00:00-06:00 时间窗刚性 → 超 90 分钟强制回退 → 执行监控 → 完工）
+
+  - sop\_netops\_escalation 重大故障升级上报（5 步：P1 判定 → 15 分钟到值班长、30 分钟首次升级 → 升级链路 → 工单 → 跟进）
+
+- **老库幂等升级 backfill\_netops\_upgrade()**：三路径互不干扰——SOP 按 slug 幂等补缺；员工-技能/员工-SOP 绑定按 emp\_id+skill\_id(sop\_id) 幂等补缺；persona/description 仅在"管理员未改动"的情况下才覆盖升级，保护自定义修改
+
+- **本体扩展：算网资源域**：新增实体类型 机房(datacenter)/算力节点(compute\_node)/传输链路(link)，关系类型 部署于(deploy\_in)/回传链路(backhaul)；种子播种 2 机房、4 算力节点、3 传输链路 + 4 条 deploy\_in + 4 条 backhaul 关系，与本体已有基站/片区可直接组合多跳查询；函数 `seed_netops_resources_if_empty()` 幂等
+
+- **三份算网演示数据集 + 生成脚本**（scripts/generate\_netops\_data.py，固定随机种子可复现）：
+
+  - netops\_alerts.csv：378 条告警（90 天），P1-P4 四档，埋三条故事线：城东 8/8-8/10 连续 P1 板卡故障、高新 2 号站近 30 天 P2 传输故障频发、周末突发故障
+
+  - netops\_kpi.csv：181 天 × 3 片区的接通率/掉线率/SLA/满意度，KPI 与城东大障日同步跌落
+
+  - netops\_resources.csv：12 条三类资源台账，GPU 训练节点 92.2% + 高新-下沙光缆 87.0% 命中预警
+
+- **专项回归测试 tests/test\_netops\_expert.py（10 条全通过）**：覆盖数据结构/故事线/yaml/触发条件/SOP 播种/backfill 双路径（空库/老库）/本体幂等；pytest 夹具 `tmp_db` 保证 SQLite 不碰真实数据
+
+- **E2E 手动验证脚本 scripts/verify\_netops\_e2e.py**：4 个典型问题 HTTP API 直跑（登录→改密→会话→SSE 流），自动核对工具调用与回答要点，便于改动后的冒烟
 
 ### 优化
 
-- README 与 .env.example 中 APP_VERSION 示例值从历史遗留的 0.4.0/0.6.0 统一追平到 0.8.0
+- README 与 .env.example 中 APP\_VERSION 示例值从历史遗留的 0.4.0/0.6.0 统一追平到 0.8.0
 
----
+***
 
 ## 0.5.0 (2026-08-27)
 
 ### 新增
 
 - **MCP 连接器支持 HTTP transport**（#12）：连接器配置 `transport: "http"`（或 `streamable-http` / `streamable_http`）归一化为 Streamable HTTP 接入，url 原样透传；资源中心可直接接入远程 HTTP 型 MCP server（如 scrapling），无需本地子进程。stdio 行为不变
+
 - **网络运营数字员工「小网」**（#10）：内置员工增至 6 个，网络运营专家岗位打样——故障影响分析技能（基站退服 → 覆盖片区 → 受影响客户 → 筛 VIP → 装维责任人 → 登记工单），完整展示企业本体多跳关系查询能力
-- **本体扩展：网络运营领域**（#10）：新增实体类型 基站(station) / 片区(area)，关系类型 覆盖(cover) / 维护(maintain) / 居住于(located_in)；网络运营演示数据「星联通信」（1 组织 / 4 员工 / 4 基站 / 3 片区 / 5 客户），含退服基站 BS-003 场景
+
+- **本体扩展：网络运营领域**（#10）：新增实体类型 基站(station) / 片区(area)，关系类型 覆盖(cover) / 维护(maintain) / 居住于(located\_in)；网络运营演示数据「星联通信」（1 组织 / 4 员工 / 4 基站 / 3 片区 / 5 客户），含退服基站 BS-003 场景
+
 - **本体老库平滑升级**（#10）：`backfill_schema_types()` 幂等补齐新增预置类型；`backfill_employees_if_missing()` 幂等补种新内置员工（含技能/工具/授权），已有库无需清库重建
+
 - **本体关系图谱**（#7）：本体页新增「关系图谱」tab，echarts 力导向布局——实体为节点、关系为连线，按实体类型着色 + 图例过滤、连线显示中文关系名、节点大小随关联数变化、悬停高亮邻接、点击节点打开详情、可拖拽/缩放/重新布局
 
 ### 优化
 
 - 本体全面中文化显示（#6）：业务关系表格、实体详情、类型定义、下拉选择等处统一显示类型中文名（悬停保留 code），未定义中文名时回退 code
+
 - 类型定义支持编辑保存（#7）：修复编辑弹窗只调创建接口（POST）导致"code 已存在"报错的 bug，编辑走 PUT
 
 ### 修复
 
 - 表格 render 函数内按钮改用真实组件对象渲染（#9）：修复本体页操作列按钮无手型光标、无样式、间距挤的问题；编辑/删除按钮配色与间距同会话历史页风格统一（编辑主题蓝、删除红色）
+
 - 类型系统放开预置类型只读限制（#8）：预置实体/关系类型可编辑与软删除（code 仍不可改），配合演示数据场景灵活调整
+
 - 中文 README 移除残留的英文简介段落，双语同步 net-ops 员工信息（#11）
 
----
+***
 
 ## 0.4.0 (2026-08-27)
 
 ### 重磅变更：数据库迁移 PostgreSQL
 
 - **存储后端由 SQLite 整体切换为 PostgreSQL**（#3）：面向多用户并发与网络访问的企业共享部署场景，SQLite 单写锁不再适用
+
 - 新增 `app/db.py` 双方言数据访问层：psycopg 连接池 + SQL 方言翻译（`INSERT OR IGNORE→ON CONFLICT`、`AUTOINCREMENT→IDENTITY`、`?→%s`），业务代码保持统一写法；`DB_BACKEND=sqlite` 分支仅测试夹具使用
+
 - checkpointer / store 切换为官方 `langgraph-checkpoint-postgres`（`AsyncPostgresSaver` / `AsyncPostgresStore`），`streaming.py` 启动恢复兼容 PG 表结构
+
 - catalog / conversations / traces / approvals / ontology 全部接入访问层；修复 users 主键秒级时间戳碰撞问题
+
 - `docker-compose.yml` 新增 `db` 服务（postgres:16-alpine，首启自动建 7 个业务库）；新增 `scripts/init_postgres.sql` 与幂等建库脚本 `scripts/init_postgres.sh`（支持 `--host/--port/--prefix`）
+
 - `backup.sh` 改用 `pg_dump`（支持 `PGBIN` 指定路径）；requirements 增补 psycopg / checkpoint-postgres
+
 - **升级注意**：`DB_BACKEND=postgres` + `POSTGRES_*` 环境变量必填（见 `.env.example`），存量 SQLite 数据需自行迁入
 
 ### 新增
 
 - 运行评估功能：每条回答 👍/👎 反馈（含点踩原因浮层），管理员评估仪表盘（指标卡片 + 日趋势 + Top 工具 + 反馈明细，`AdminEvaluation.vue`）；SSE 新增 `message_end` 事件携带反馈关联 ID
+
 - 对话附件上传：`/api/conversations/{id}/attachments`（单文件 20MB 限制），附件路径注入消息文本，前端输入栏支持附件选择与消息内附件标签
+
 - 运行 / 工具错误在对话页可见化，用户不再只看到静默失败
+
 - 前端聊天视图组件化：ChatView 拆分为 InputBar / ChatMessage / PipelineSidebar / ConversationSidebar / ReasonPopover
-- 开源就绪：CI（后端 pytest + 前端构建）、issue 模板、PR 模板、CODE_OF_CONDUCT / SECURITY / CONTRIBUTING 社区文件
+
+- 开源就绪：CI（后端 pytest + 前端构建）、issue 模板、PR 模板、CODE\_OF\_CONDUCT / SECURITY / CONTRIBUTING 社区文件
+
 - 英文 README（`README.en.md`），中英双语切换；LICENSE 修复为标准 MIT 全文，GitHub 正确识别
 
 ### 修复
 
 - 过滤 `content` 内联思考标签，防止污染会话标题生成与历史消息展示（#2）
+
 - 恢复消息评价按钮——聊天视图组件拆分时遗漏了 `message_end` 事件处理导致 `run_id` 为空
+
 - 可靠性修复：文档工具数据按用户隔离、trace 写入失败可观测（不再静默吞错）、退款审批双路径补充测试
+
 - 修复全新环境启动与退款审批路径的 bug（开源前回归）
 
----
+***
 
 ## 0.3.1 (2026-08-04)
 
 ### 新增
+
 - 技能动态 Store 同步：新增 `runtime.sync_skills_to_store()`，`get_agent()` 编译前会把当前员工技能内容接入 Store
+
 - 新增 `PUT /admin/skills/{skill_id}/content` 接口：直接保存自定义技能 SKILL.md 内容
+
 - 技能 zip 上传/内容变更后只刷新 Store，不再触发 agent 重编译
+
 - 前端技能编辑弹窗支持直接修改 SKILL.md 内容保存（未选择 zip 且编辑自定义技能时）
+
 - 新增 `runtime.refresh_skills_for_employees()`，技能变更统一刷新受影响员工
+
 - `run_python` 增加代码长度 / 输出大小资源限制，默认 20000 字符输入、6000 字符输出，可环境变量覆盖
+
 - 技能 Store 命名空间按用户隔离：`/skills/` 路由从 `(emp_id)` 调整为 `(user_id or "default", emp_id)`，不同用户视角的技能集合互不覆盖
+
 - 临时提供 `MCP_DISABLED=1` 启动开关，MCP stdio 初始化失败时不再拖垮服务
+
 - IM 频道第一批（Web）：新增 `/api/im/*` 频道接口，启动时自动创建“全员频道”，频道内可选择数字员工、查看会话历史、SSE 流式回复
+
 - 前端 `/app/im` 从占位页替换为 `ImView.vue`，左侧频道列表 + 会话列表 + 聊天区，并复用现有 SSE Markdown / 工具 trace / 审批卡片渲染
 
 ### 修复
+
 - 修复技能运行时无法感知 SKILL.md 内容变更的问题
+
 - 修复前端技能编辑弹窗 `openModal` 使用 `await` 但函数未声明 `async` 的编译错误
-- 技能路由保持轻量摘要：SKILL.md 全文不进入 system_prompt，详细规程通过 Store/read_file 运行时读取（新增契约测试）
+
+- 技能路由保持轻量摘要：SKILL.md 全文不进入 system\_prompt，详细规程通过 Store/read\_file 运行时读取（新增契约测试）
+
 - 清理 `tools/kb.py` 死代码 `kb_search`，运行时统一使用 `compiler.make_kb_search` 闭包
+
 - 新增 `runtime.refresh_skills()` 统一技能刷新入口；用户覆盖变化只刷新用户技能视图并清用户变体缓存
+
 - `kb_search` 改为运行时动态查询 catalog，知识库条目不再作为编译期快照固化进工具闭包
+
 - 知识库条目 add/edit/delete 不再触发 agent 重编译，运行时 `kb_search` 自动读取最新条目
-- SOP 动态加载：`/sops/` Store 路由 + `sync_sops_to_store()`，SOP 全文不再拼进 system_prompt，编辑 SOP 后只刷新 Store
+
+- SOP 动态加载：`/sops/` Store 路由 + `sync_sops_to_store()`，SOP 全文不再拼进 system\_prompt，编辑 SOP 后只刷新 Store
+
 - SSE 错误分级：`_stream_run` 异常不再把内部异常文本直接返回前端，改为稳定 `error_code` + 通用提示
+
 - `reconstruct()` 并行工具调用结果不再按顺序错配，改为优先按 `tool_call_id` 精确匹配（结果乱序时也能对应正确的工具调用）
+
 - `recover_conversations()` 增加启动恢复条数上限，默认 `CONV_RECOVER_LIMIT=2000`，避免启动全表扫描
+
 - `employee_of()` 在员工目录为空时不再抛 `IndexError`，返回明确 SSE 错误提示
+
 - 审批中心从内存版改为 SQLite 落库（`approvals.db`）：生效 `APPROVAL_TTL_SECONDS` 过期自动拒绝、`APPROVAL_PENDING_LIMIT` pending 数量上限
+
 - 新增 `runtime.shutdown_mcp()`：应用退出时统一关闭 MCP client（优先 `aclose`，回退 `__aexit__`），避免 stdio 子进程残留
+
 - 前端 SSE 流式请求增加 `AbortController`：页面卸载或发起新请求时中断旧连接，避免服务端挂起时连接不释放
+
 - `.dockerignore` 补全 `frontend/dist/`、`.pytest_cache/` 等缓存目录，镜像构建上下文更干净
+
 - 确认强制改密 API 层拦截已生效：`must_change_password=true` 的用户只能访问登录/改密/当前用户接口，其余 `/api` 返回 403
+
 - 修复管理后台点击左侧菜单整页闪一下的问题：`/app` 子路由不再重建 `MainLayout`，左侧栏保持稳定，内容区独立淡入淡出
 
 ### 技术债
+
 - 待办新增 `P6 核心能力动态化（技能 / 知识库 / SOP / MCP）`，用于持续推进“编译期固化”改为“运行时可读取/可分配”
 
----
+***
 
 ## 0.3.0 (2026-07-26)
 
 ### 重构
+
 - 移动 5 个 SQLite 数据库从根目录到 `data/db/`，`paths.py` 默认路径同步更新
+
 - 删除废弃的 `app/static/` HTML 文件（已被 `frontend/src/` Vue 前端替代）
+
 - 所有 `.vue`/`.js` 文件顶部加中文文件说明，`__init__.py` 补充包说明
 
 ### 新增
+
 - 前端可复用分页组件 `PaginationBar.vue`
+
 - 知识库条目详情弹窗（查看完整内容）
+
 - SOP 展开/收起全文
+
 - 技能内容查看弹窗（SKILL.md 全文）
+
 - 技能编辑弹窗新增 SKILL.md 内容字段
+
 - 公共知识库条目只读接口 `GET /api/knowledge-bases/{id}/entries`
+
 - `pyproject.toml` 项目元数据文件
+
 - `CLAUDE.md`、`TODO.md` 项目文档
 
 ### 修复
+
 - 前端路由跳转全部改为按 name 跳转，解决绝对路径不匹配子路由的问题
+
 - 左侧菜单切换闪烁（移除 transition + 改用 keep-alive 缓存组件）
+
 - ChatView 缺失 `useRouter` 导入导致"执行过程"按钮无反应
+
 - HistoryView 缺失 `reactive` 导入导致页面空白
+
 - 资源中心知识库条目 API 路径 `/admin/kbs/` → `/admin/knowledge-bases/`
+
 - 资源中心普通用户无法查看知识库条目（后端新增公共 API）
+
 - Trace 默认折叠（traceExpanded: true → false）
+
 - "执行过程"链接从 `<a href="/trace">` 改为 `router.resolve`
+
 - $router.push('/history') 改为 `{name:'history'}`
 
 ### 丰富
+
 - FAQ 知识库从 6 条扩展到 30 条（5 产品线 + 通用政策）
-- MOCK_ORDERS 从 3 个扩展到 10 个
+
+- MOCK\_ORDERS 从 3 个扩展到 10 个
+
 - CRM 客户从 2 个扩展到 6 个
+
 - 销售数据集从 2 产品 × 24 行扩展到 5 产品 × 60 行
+
 - SOP 内容全部重写为完整版本
+
 - product-faq / complaint-handling 技能文档扩充
+
 - 小苏 / 小数人设扩充
 
 ### 管理后台
+
 - 资源中心对普通用户可见（只读，admin 有全部 CRUD 权限）
+
 - 员工管理 + 用户管理插入主导航（仅 admin 可见）
+
 - 首页统计修复（并行调用 /employees + /catalog + /conversations）
 
----
+***
 
 ## 0.2.0 (2026-07-24)
 
 ### 新增
+
 - 前端 Vue 3 + Vite + Naive UI 重构
+
 - 对话 SSE 流式响应
+
 - HITL 审批决策
+
 - 执行过程追踪（traces）
+
 - 用户 - 员工分配机制
+
 - 资源中心（技能/工具/知识库/SOP/连接器 CRUD）
 
 ### 修复
+
 - 软删除各实体级联关系
+
 - 登录限流
+
 - XSS 消毒
 
----
+***
 
 ## 0.1.0 (2026-07-22)
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ UniEmployee/
 | `JWT_EXPIRE_HOURS` | `24` | token 有效期（小时） |
 | `LOG_LEVEL` / `LOG_FILE` | `INFO` / 空 | 日志级别 / 文件路径 |
 | `DB_BACKEND` / `POSTGRES_*` | `postgres` | 数据库后端与连接参数（host/port/user/password/db 前缀） |
-| `APP_VERSION` | `0.9.0` | 打印在 /health 与日志 |
+| `APP_VERSION` | `0.10.0` | 打印在 /health 与日志 |
 | `PRODUCT_WIKI_DIR` | `product-wiki/` | 销售技能的产品知识库 markdown 目录 |
 | `RAGFLOW_BASE_URL` / `RAGFLOW_API_KEY` / `RAGFLOW_DATASET_IDS` | — | RAGFlow 知识库接入（可选） |
 

--- a/backend/app/automations.py
+++ b/backend/app/automations.py
@@ -1,0 +1,341 @@
+"""自动化任务：定时(cron) / 事件触发，自动起 run 并推送结果。
+
+两类触发器统一为 automation 记录：
+- cron : 5 字段 cron 表达式（服务器本地时间），调度器每 30s 扫描 next_fire_at 到期任务
+- event: 外部系统 POST /api/automations/events/{event_key}（可配 secret 校验）
+
+执行复用 streaming._stream_run——护栏、长期记忆、Trace 全走现有链路；
+结果落会话（run_as 用户在会话历史/IM 频道可见），可选经频道
+outbound_webhook 推送到外部 IM。
+
+表结构与 channels 同库（conversations.db），双方言（sqlite/postgres）。
+"""
+import json
+import logging
+import time
+from datetime import datetime, timedelta
+
+import httpx
+
+from app import conversations
+
+log = logging.getLogger("app.automations")
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS automations (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    trigger_type TEXT NOT NULL DEFAULT 'cron',
+    cron_expr    TEXT DEFAULT '',
+    event_key    TEXT DEFAULT '',
+    secret       TEXT DEFAULT '',
+    employee_id  TEXT NOT NULL,
+    prompt       TEXT NOT NULL,
+    run_as       TEXT DEFAULT 'default',
+    channel_id   TEXT DEFAULT '',
+    enabled      INTEGER DEFAULT 1,
+    next_fire_at TEXT,
+    last_run_at  TEXT,
+    last_status  TEXT DEFAULT '',
+    last_error   TEXT DEFAULT '',
+    last_conv_id TEXT,
+    run_count    INTEGER DEFAULT 0,
+    created_by   TEXT,
+    created_at   TEXT,
+    updated_at   TEXT
+);
+"""
+
+TS = "%Y-%m-%dT%H:%M"          # 触发点（分钟精度，字符串比较即时间比较）
+TS_FULL = "%Y-%m-%dT%H:%M:%S"  # 记录时间戳
+
+
+def _conn():
+    """复用 conversations 的连接入口（同库；测试夹具 patch conversations.DB
+    时自动跟随），再补建 automations 表。"""
+    con = conversations._conn()
+    con.executescript(_DDL)
+    return con
+
+
+# ---------------------------------------------------------------------------
+# cron 解析（5 字段：分 时 日 月 周；支持 * / , - 与 7=周日）
+# ---------------------------------------------------------------------------
+
+def _parse_field(expr: str, lo: int, hi: int) -> set[int] | None:
+    """单字段 -> 值集合；None 表示 '*'（任意值）。"""
+    values: set[int] = set()
+    for part in expr.strip().split(","):
+        part = part.strip()
+        if not part:
+            raise ValueError(f"cron 字段含空段: {expr!r}")
+        step = 1
+        if "/" in part:
+            part, step_s = part.split("/", 1)
+            step = int(step_s)
+            if step <= 0:
+                raise ValueError(f"cron 步长必须为正: {expr!r}")
+        if part == "*":
+            if step == 1:
+                return None
+            values.update(range(lo, hi + 1, step))
+            continue
+        if "-" in part:
+            a, b = part.split("-", 1)
+            start, end = int(a), int(b)
+            if not (lo <= start <= hi and lo <= end <= hi and start <= end):
+                raise ValueError(f"cron 范围越界: {part!r}（允许 {lo}-{hi}）")
+        else:
+            start = end = int(part)
+            if not (lo <= start <= hi):
+                raise ValueError(f"cron 值越界: {part!r}（允许 {lo}-{hi}）")
+        values.update(range(start, end + 1, step))
+    if not values:
+        raise ValueError(f"cron 字段无有效值: {expr!r}")
+    return values
+
+
+def parse_cron(expr: str):
+    """解析 5 字段 cron 表达式，返回 (minute, hour, dom, month, dow)。"""
+    fields = expr.split()
+    if len(fields) != 5:
+        raise ValueError("cron 表达式需要 5 个字段：分 时 日 月 周")
+    dow = _parse_field(fields[4], 0, 7)
+    if dow is not None:  # cron 里 7 也表示周日
+        dow = {0 if v == 7 else v for v in dow}
+    return (_parse_field(fields[0], 0, 59), _parse_field(fields[1], 0, 23),
+            _parse_field(fields[2], 1, 31), _parse_field(fields[3], 1, 12), dow)
+
+
+def cron_match(parsed, dt: datetime) -> bool:
+    """判断 dt 是否命中 cron（标准语义：日与周都受限时取并集）。"""
+    minute, hour, dom, month, dow = parsed
+    if minute is not None and dt.minute not in minute:
+        return False
+    if hour is not None and dt.hour not in hour:
+        return False
+    if month is not None and dt.month not in month:
+        return False
+    dom_ok = dom is None or dt.day in dom
+    dow_ok = dow is None or (dt.weekday() + 1) % 7 in dow  # 0=周日
+    if dom is not None and dow is not None:
+        return dom_ok or dow_ok
+    return dom_ok and dow_ok
+
+
+def next_fire(expr: str, after: datetime, max_minutes: int = 527040) -> datetime | None:
+    """after 之后的下一个触发时间；一年内无匹配返回 None（如 2/30）。"""
+    parsed = parse_cron(expr)
+    t = after.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    for _ in range(max_minutes):
+        if cron_match(parsed, t):
+            return t
+        t += timedelta(minutes=1)
+    return None
+
+
+def validate_cron(expr: str) -> str:
+    """校验表达式并确认一年内有触发点，返回错误信息（空串=合法）。"""
+    try:
+        if next_fire(expr, datetime.now()) is None:
+            return "该表达式一年内没有可触发的时间点"
+        return ""
+    except ValueError as e:
+        return str(e)
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+def _row(r) -> dict:
+    d = dict(r)
+    d["enabled"] = bool(d.get("enabled"))
+    return d
+
+
+def create(name: str, trigger_type: str, employee_id: str, prompt: str,
+           cron_expr: str = "", event_key: str = "", secret: str = "",
+           run_as: str = "default", channel_id: str = "", enabled: bool = True,
+           created_by: str = "") -> dict:
+    aid = "auto_" + time.strftime("%Y%m%d%H%M%S") + str(time.time()).split(".")[1]
+    now = time.strftime(TS_FULL)
+    next_fire_at = None
+    if trigger_type == "cron" and enabled:
+        nxt = next_fire(cron_expr, datetime.now())
+        next_fire_at = nxt.strftime(TS) if nxt else None
+    with _conn() as con:
+        con.execute(
+            "INSERT INTO automations"
+            "(id, name, trigger_type, cron_expr, event_key, secret, employee_id, prompt,"
+            " run_as, channel_id, enabled, next_fire_at, created_by, created_at, updated_at) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (aid, name, trigger_type, cron_expr, event_key, secret, employee_id,
+             prompt, run_as or "default", channel_id, 1 if enabled else 0,
+             next_fire_at, created_by, now, now))
+        con.commit()
+    return get(aid) or {}
+
+
+def update(aid: str, **fields) -> dict | None:
+    """局部更新；cron 字段变化时重算 next_fire_at。"""
+    auto = get(aid)
+    if not auto:
+        return None
+    merged = {**auto, **{k: v for k, v in fields.items() if v is not None}}
+    now = time.strftime(TS_FULL)
+    next_fire_at = auto.get("next_fire_at")
+    if merged["trigger_type"] == "cron":
+        if merged["enabled"]:
+            nxt = next_fire(merged["cron_expr"], datetime.now())
+            next_fire_at = nxt.strftime(TS) if nxt else None
+        else:
+            next_fire_at = None
+    with _conn() as con:
+        con.execute(
+            "UPDATE automations SET name=?, trigger_type=?, cron_expr=?, event_key=?,"
+            " secret=?, employee_id=?, prompt=?, run_as=?, channel_id=?, enabled=?,"
+            " next_fire_at=?, updated_at=? WHERE id=?",
+            (merged["name"], merged["trigger_type"], merged["cron_expr"],
+             merged["event_key"], merged["secret"], merged["employee_id"],
+             merged["prompt"], merged["run_as"] or "default", merged["channel_id"],
+             1 if merged["enabled"] else 0, next_fire_at, now, aid))
+        con.commit()
+    return get(aid)
+
+
+def delete(aid: str) -> bool:
+    with _conn() as con:
+        cur = con.execute("DELETE FROM automations WHERE id=?", (aid,))
+        ok = cur.rowcount > 0
+        con.commit()
+    return ok
+
+
+def get(aid: str) -> dict | None:
+    with _conn() as con:
+        r = con.execute("SELECT * FROM automations WHERE id=?", (aid,)).fetchone()
+    return _row(r) if r else None
+
+
+def list_all() -> list[dict]:
+    with _conn() as con:
+        rows = con.execute(
+            "SELECT * FROM automations ORDER BY created_at DESC, id DESC").fetchall()
+    return [_row(r) for r in rows]
+
+
+def list_by_event(event_key: str) -> list[dict]:
+    with _conn() as con:
+        rows = con.execute(
+            "SELECT * FROM automations WHERE trigger_type='event' AND enabled=1 "
+            "AND event_key=?", (event_key,)).fetchall()
+    return [_row(r) for r in rows]
+
+
+def due_crons(now_minute: str) -> list[dict]:
+    """到期（next_fire_at <= now）且启用的 cron 任务。"""
+    with _conn() as con:
+        rows = con.execute(
+            "SELECT * FROM automations WHERE trigger_type='cron' AND enabled=1 "
+            "AND next_fire_at IS NOT NULL AND next_fire_at<=? ORDER BY next_fire_at",
+            (now_minute,)).fetchall()
+    return [_row(r) for r in rows]
+
+
+def claim_next(aid: str, expected_next: str, new_next: str | None) -> bool:
+    """CAS 抢占触发点：多实例/慢执行重入时只有一个赢家。"""
+    with _conn() as con:
+        cur = con.execute(
+            "UPDATE automations SET next_fire_at=?, last_status='running', updated_at=? "
+            "WHERE id=? AND next_fire_at=?",
+            (new_next, time.strftime(TS_FULL), aid, expected_next))
+        ok = cur.rowcount > 0
+        con.commit()
+    return ok
+
+
+def mark_result(aid: str, status: str, error: str = "", conv_id: str = "") -> None:
+    with _conn() as con:
+        con.execute(
+            "UPDATE automations SET last_run_at=?, last_status=?, last_error=?,"
+            " last_conv_id=?, run_count=run_count+1, updated_at=? WHERE id=?",
+            (time.strftime(TS_FULL), status, error[:500], conv_id,
+             time.strftime(TS_FULL), aid))
+        con.commit()
+
+
+# ---------------------------------------------------------------------------
+# 执行引擎：复用 _stream_run，结果落会话 + 可选推送
+# ---------------------------------------------------------------------------
+
+def render_prompt(template: str, payload=None) -> str:
+    """模板渲染：{{now}} 当前时间；{{payload}} 事件数据（JSON）。"""
+    out = template.replace("{{now}}", time.strftime("%Y-%m-%d %H:%M:%S"))
+    if payload is not None:
+        blob = json.dumps(payload, ensure_ascii=False)
+        if "{{payload}}" in out:
+            out = out.replace("{{payload}}", blob)
+        else:  # 模板没占位但事件带了数据：附加在尾部，保证员工能看到
+            out = f"{out}\n\n[事件数据]\n{blob}"
+    return out
+
+
+async def _push(channel: dict, conv_id: str, reply: str) -> None:
+    cfg = channel.get("config") or {}
+    url = cfg.get("outbound_webhook")
+    if not url or not reply:
+        return
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(url, json={
+                "conversation_id": conv_id,
+                "channel_id": channel["id"],
+                "message": reply,
+            })
+    except Exception:
+        log.warning("自动任务结果推送失败 channel=%s", channel.get("id"), exc_info=True)
+
+
+async def execute(auto: dict, payload=None, trigger: str = "cron") -> dict:
+    """执行一次自动任务：新建会话 -> 跑 agent -> 记状态 -> 可选推送。"""
+    from app.streaming import _stream_run  # 延迟导入避免环
+
+    emp_id = auto["employee_id"]
+    user_id = auto.get("run_as") or "default"
+    prompt = render_prompt(auto["prompt"], payload)
+    suffix = time.strftime("%Y%m%d%H%M%S") + str(time.time()).split(".")[1]
+    conv_id = f"c_auto_{auto['id']}_{suffix}"
+    channel = conversations.get_channel(auto["channel_id"]) if auto.get("channel_id") else None
+
+    conversations.create(conv_id, emp_id, user_id=user_id,
+                         channel_id=auto.get("channel_id") or None,
+                         title=f"[自动] {auto['name']}"[:40],
+                         preview=prompt[:60], count=1)
+    input_ = {"messages": [{"role": "user", "content": prompt}]}
+    parts: list[str] = []
+    status, error = "ok", ""
+    try:
+        async for raw in _stream_run(conv_id, input_, user_id=user_id, role="user"):
+            if not raw.startswith("data: "):
+                continue
+            try:
+                ev = json.loads(raw[len("data: "):])
+            except Exception:
+                continue
+            if ev.get("type") == "token":
+                parts.append(ev.get("content", ""))
+            elif ev.get("type") == "error":
+                status, error = "error", ev.get("message", "任务执行出错")
+    except Exception as e:
+        status, error = "error", f"{type(e).__name__}: {e}"
+        log.exception("自动任务执行异常 id=%s", auto["id"])
+
+    reply = "".join(parts).strip()
+    mark_result(auto["id"], status, error, conv_id)
+    if reply:
+        conversations.touch(conv_id, preview=reply[:60], bump=1)
+    if channel:
+        await _push(channel, conv_id, reply)
+    return {"conversation_id": conv_id, "status": status, "error": error,
+            "reply": reply}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from app import auth, catalog, conversations, ontology, runtime
+from app import auth, catalog, conversations, ontology, runtime, scheduler
 from app import db as dblayer
 from app.paths import db_path, DB_FILES, PROJECT_ROOT
 from app.logging_setup import setup_logging, request_id_var, get_logger
@@ -27,7 +27,7 @@ from app.errors import register_exception_handlers
 from app.streaming import recover_conversations
 from app.routes import router as app_router
 
-APP_VERSION = os.environ.get("APP_VERSION", "0.9.0")
+APP_VERSION = os.environ.get("APP_VERSION", "0.10.0")
 log = get_logger("app.main")
 
 # 用户被标记 must_change_password 时仍可访问的接口：登录、改密、当前用户信息。
@@ -93,8 +93,10 @@ async def lifespan(app):
         runtime.set_store(store)
         await runtime.warmup_all()
         await recover_conversations()
+        scheduler.start()
         log.info("启动完成，开始接收请求")
         yield
+        await scheduler.stop()
         await runtime.shutdown_mcp()
         if dblayer.is_pg():
             dblayer.close_all_pools()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -90,3 +90,34 @@ class ImIncomingMessage(BaseModel):
     message: str
     employee_id: str | None = None
     secret: str | None = None
+
+
+class AutomationCreate(BaseModel):
+    name: str
+    trigger_type: str = "cron"          # cron | event
+    cron_expr: str = ""                 # cron：分 时 日 月 周（服务器本地时间）
+    event_key: str = ""                 # event：事件标识，如 order.refunded
+    secret: str = ""                    # event：可选 secret 校验
+    employee_id: str = ""               # 执行员工
+    prompt: str = ""                    # 任务指令（支持 {{now}} / {{payload}}）
+    run_as: str = ""                    # 以哪个用户身份运行（记忆/可见归属）
+    channel_id: str = ""                # 可选：结果推送频道（outbound_webhook）
+    enabled: bool = True
+
+
+class AutomationUpdate(BaseModel):
+    name: str | None = None
+    trigger_type: str | None = None
+    cron_expr: str | None = None
+    event_key: str | None = None
+    secret: str | None = None
+    employee_id: str | None = None
+    prompt: str | None = None
+    run_as: str | None = None
+    channel_id: str | None = None
+    enabled: bool | None = None
+
+
+class AutomationEventIn(BaseModel):
+    payload: object = None              # 事件数据（注入 {{payload}}）
+    secret: str | None = None

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -21,6 +21,7 @@ from .public import router as public_router
 from .im import router as im_router
 from .guard import router as guard_router
 from .audit import router as audit_router
+from .automations import router as automation_router
 
 router = APIRouter()
 router.include_router(auth_router)
@@ -34,3 +35,4 @@ router.include_router(public_router)
 router.include_router(im_router)
 router.include_router(guard_router)
 router.include_router(audit_router)
+router.include_router(automation_router)

--- a/backend/app/routes/automations.py
+++ b/backend/app/routes/automations.py
@@ -1,0 +1,130 @@
+"""自动化任务路由：定时/事件任务的 CRUD、手动运行、事件 webhook 入口。
+
+- 管理 API（/api/automations/*）仅 admin 可用
+- 事件入口 POST /api/automations/events/{event_key} 面向外部系统，
+  靠任务级 secret 校验（未配置 secret 则直接放行）
+"""
+from fastapi import APIRouter, Depends, HTTPException
+
+from app import automations, auth, runtime
+from app.models import (
+    AutomationCreate, AutomationUpdate, AutomationEventIn,
+)
+
+router = APIRouter(prefix="/api/automations", tags=["automations"])
+
+
+def _require_admin(user: dict):
+    if user.get("role") != "admin":
+        raise HTTPException(403, "仅管理员可管理自动化任务")
+
+
+def _validate(body) -> None:
+    if body.trigger_type not in ("cron", "event"):
+        raise HTTPException(400, "trigger_type 仅支持 cron / event")
+    if not body.prompt or not body.prompt.strip():
+        raise HTTPException(400, "任务指令（prompt）不能为空")
+    if not any(e["id"] == body.employee_id for e in runtime.discover_employees()):
+        raise HTTPException(400, f"数字员工不存在：{body.employee_id}")
+    if body.trigger_type == "cron":
+        err = automations.validate_cron(body.cron_expr or "")
+        if err:
+            raise HTTPException(400, f"cron 表达式不合法：{err}")
+    else:
+        if not (body.event_key or "").strip():
+            raise HTTPException(400, "事件触发必须填写事件标识（event_key）")
+
+
+def _item(auto: dict) -> dict:
+    item = {**auto}
+    if auto.get("trigger_type") == "event" and auto.get("event_key"):
+        item["event_url"] = f"/api/automations/events/{auto['event_key']}"
+    return item
+
+
+@router.get("")
+async def list_automations(user: dict = Depends(auth.get_current_user_or_fallback)):
+    _require_admin(user)
+    return {"items": [_item(a) for a in automations.list_all()]}
+
+
+@router.post("")
+async def create_automation(body: AutomationCreate,
+                            user: dict = Depends(auth.get_current_user_or_fallback)):
+    _require_admin(user)
+    _validate(body)
+    auto = automations.create(
+        name=body.name.strip(), trigger_type=body.trigger_type,
+        employee_id=body.employee_id, prompt=body.prompt.strip(),
+        cron_expr=body.cron_expr or "", event_key=(body.event_key or "").strip(),
+        secret=body.secret or "", run_as=body.run_as or user.get("id", "default"),
+        channel_id=body.channel_id or "", enabled=body.enabled,
+        created_by=user.get("id", ""))
+    return _item(auto)
+
+
+@router.put("/{aid}")
+async def update_automation(aid: str, body: AutomationUpdate,
+                            user: dict = Depends(auth.get_current_user_or_fallback)):
+    _require_admin(user)
+    current = automations.get(aid)
+    if not current:
+        raise HTTPException(404, "任务不存在")
+    merged = AutomationCreate(
+        name=body.name if body.name is not None else current["name"],
+        trigger_type=body.trigger_type or current["trigger_type"],
+        cron_expr=body.cron_expr if body.cron_expr is not None else current["cron_expr"],
+        event_key=body.event_key if body.event_key is not None else current["event_key"],
+        secret=body.secret if body.secret is not None else current["secret"],
+        employee_id=body.employee_id or current["employee_id"],
+        prompt=body.prompt if body.prompt is not None else current["prompt"],
+        run_as=body.run_as if body.run_as is not None else current["run_as"],
+        channel_id=body.channel_id if body.channel_id is not None else current["channel_id"],
+        enabled=body.enabled if body.enabled is not None else current["enabled"],
+    )
+    _validate(merged)
+    auto = automations.update(
+        aid, name=merged.name.strip(), trigger_type=merged.trigger_type,
+        cron_expr=merged.cron_expr or "", event_key=merged.event_key.strip(),
+        secret=merged.secret or "", employee_id=merged.employee_id,
+        prompt=merged.prompt.strip(), run_as=merged.run_as,
+        channel_id=merged.channel_id or "", enabled=merged.enabled)
+    return _item(auto or {})
+
+
+@router.delete("/{aid}")
+async def delete_automation(aid: str,
+                            user: dict = Depends(auth.get_current_user_or_fallback)):
+    _require_admin(user)
+    if not automations.delete(aid):
+        raise HTTPException(404, "任务不存在")
+    return {"ok": True}
+
+
+@router.post("/events/{event_key}")
+async def event_trigger(event_key: str, body: AutomationEventIn):
+    """外部事件入口：触发所有监听该事件的任务并返回执行结果。"""
+    autos = automations.list_by_event(event_key)
+    if not autos:
+        raise HTTPException(404, "没有启用中的任务监听该事件")
+    results = []
+    for auto in autos:
+        if auto.get("secret") and auto["secret"] != (body.secret or ""):
+            continue
+        r = await automations.execute(auto, payload=body.payload, trigger="event")
+        results.append({"id": auto["id"], "name": auto["name"], **r})
+    if not results:
+        raise HTTPException(403, "secret 校验失败")
+    return {"event": event_key, "triggered": len(results), "results": results}
+
+
+@router.post("/{aid}/run")
+async def run_automation(aid: str,
+                         user: dict = Depends(auth.get_current_user_or_fallback)):
+    """手动立即运行（验收/调试用；不影响 cron 的下次触发时间）。"""
+    _require_admin(user)
+    auto = automations.get(aid)
+    if not auto:
+        raise HTTPException(404, "任务不存在")
+    result = await automations.execute(auto, trigger="manual")
+    return result

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -1,0 +1,74 @@
+"""定时调度循环：扫描 automations 的到期 cron 任务并执行。
+
+随应用 lifespan 启动（AUTOMATIONS_DISABLED=1 可跳过）。单 worker 部署
+即可正常工作；多实例下靠 next_fire_at 的 CAS 抢占（claim_next）保证
+同一触发点只执行一次。停机期间错过的触发点只补跑一次（执行后从
+当前时间重算 next_fire_at，不追历史）。
+"""
+import asyncio
+import logging
+import os
+from datetime import datetime
+
+from app import automations
+
+log = logging.getLogger("app.scheduler")
+
+_task: asyncio.Task | None = None
+INTERVAL = 30  # 扫描周期（秒）
+
+
+async def run_due(auto: dict, now: datetime) -> None:
+    """抢占并执行一个到期任务。"""
+    nxt = automations.next_fire(auto["cron_expr"], now)
+    if not automations.claim_next(
+            auto["id"], auto["next_fire_at"],
+            nxt.strftime(automations.TS) if nxt else None):
+        return  # 已被其他实例/上一轮慢执行抢占
+    result = await automations.execute(auto, trigger="cron")
+    if result["status"] == "ok":
+        log.info("自动任务完成 id=%s name=%s conv=%s",
+                 auto["id"], auto["name"], result["conversation_id"])
+    else:
+        log.warning("自动任务失败 id=%s name=%s err=%s",
+                    auto["id"], auto["name"], result["error"])
+
+
+async def _tick() -> None:
+    now = datetime.now()
+    for auto in automations.due_crons(now.strftime(automations.TS)):
+        try:
+            await run_due(auto, now)
+        except Exception:
+            log.exception("自动任务执行异常 id=%s", auto["id"])
+
+
+async def _loop() -> None:
+    log.info("自动任务调度器已启动（每 %ss 扫描一次）", INTERVAL)
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            log.exception("调度 tick 异常")
+        await asyncio.sleep(INTERVAL)
+
+
+def start() -> None:
+    global _task
+    if os.environ.get("AUTOMATIONS_DISABLED") == "1":
+        log.info("AUTOMATIONS_DISABLED=1，跳过自动任务调度器")
+        return
+    if _task is None or _task.done():
+        _task = asyncio.create_task(_loop())
+
+
+async def stop() -> None:
+    global _task
+    if _task:
+        _task.cancel()
+        try:
+            await _task
+        except asyncio.CancelledError:
+            pass
+        _task = None
+        log.info("自动任务调度器已停止")

--- a/backend/app/traces.py
+++ b/backend/app/traces.py
@@ -114,7 +114,9 @@ def finish_run(run_id: str, status: str = "done", error: str = ""):
                 except Exception:
                     dur = None
             agg = con.execute(
-                "SELECT SUM(etype='llm') l, SUM(etype='tool') t, COALESCE(SUM(tokens),0) tk "
+                "SELECT SUM(CASE WHEN etype='llm' THEN 1 ELSE 0 END) l, "
+                "SUM(CASE WHEN etype='tool' THEN 1 ELSE 0 END) t, "
+                "COALESCE(SUM(tokens),0) tk "
                 "FROM events WHERE run_id=?", (run_id,)).fetchone()
             con.execute(
                 "UPDATE runs SET status=?, error=?, ended_at=?, duration_ms=?, "

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -103,6 +103,7 @@ const mainNavOptions = [
 
 const adminOnlyNavOptions = [
   { label: '业务本体', key: 'ontology', icon: iconEl('<path d="M20 6a3 3 0 11-4 2.83L14.35 10a3 3 0 010 3.77L15 14.4A3 3 0 1121 13a3 3 0 01-3 3 2.87 2.87 0 01-1.23-.28L15.2 17.6a3 3 0 11-1.7 1.1 2.9 2.9 0 01-.13-.43L12.4 19a3 3 0 11-1.8-2.4 2.8 2.8 0 01.1-.26L8.83 15A3 3 0 115 12a3 3 0 012-2.8l-.57-1.6a3 3 0 111.4-1L15.2 7.4a2.9 2.9 0 01.28-1.2L14 4.73A3 3 0 1120 6z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
+  { label: '自动任务', key: 'automation', icon: iconEl('<path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 2v2m0 16v2M2 12h2m16 0h2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M19.07 4.93l-1.41 1.41M6.34 17.66l-1.41 1.41" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '员工管理', key: 'admin', icon: iconEl('<path d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '用户管理', key: 'users', icon: iconEl('<path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '运行评估', key: 'evaluation', icon: iconEl('<path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
@@ -129,6 +130,7 @@ const pageTitleMap = {
   trace: '执行过程', resources: '资源中心',
   admin: '员工管理', users: '用户管理', 'change-password': '修改密码',
   im: 'IM 频道', ontology: '业务本体', cases: '案例', 'case-detail': '案例详情',
+  automation: '自动任务',
   evaluation: '运行评估', profile: '个人档案',
   settings: '系统设置',
   'guard-words': '系统设置 · 安全护栏', 'guard-tools': '系统设置 · 安全护栏',

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -47,6 +47,7 @@ const routes = [
       },
       { path: 'users', name: 'users', component: () => import('../views/UsersView.vue') },
       { path: 'resources', name: 'resources', component: () => import('../views/ResourcesView.vue') },
+      { path: 'automation', name: 'automation', component: () => import('../views/AutomationView.vue') },
       { path: 'ontology', name: 'ontology', component: () => import('../views/OntologyView.vue') },
       { path: 'evaluation', name: 'evaluation', component: () => import('../views/AdminEvaluation.vue') },
       {

--- a/frontend/src/views/AutomationView.vue
+++ b/frontend/src/views/AutomationView.vue
@@ -1,0 +1,314 @@
+<!-- 自动任务：定时(cron) / 事件触发的自动化执行管理页（admin）。
+     任务执行复用对话链路（护栏/记忆/Trace），结果落会话，可选经频道 outbound_webhook 推送。 -->
+<template>
+  <div class="auto-page">
+    <div class="toolbar">
+      <div class="intro">
+        <div class="intro-title">自动化任务</div>
+        <div class="intro-sub">定时（cron）或事件触发数字员工自动执行任务；结果落会话历史，配置推送频道后可推送到外部 IM</div>
+      </div>
+      <n-button type="primary" size="small" @click="openCreate">新建任务</n-button>
+    </div>
+
+    <n-data-table :columns="columns" :data="items" :loading="loading" :bordered="false"
+                  size="small" :row-key="r => r.id" :pagination="false" />
+    <n-empty v-if="!loading && !items.length" description="还没有自动化任务，点击右上角新建" style="padding: 48px 0" />
+
+    <!-- 新建 / 编辑 -->
+    <n-modal v-model:show="showForm" preset="card" :title="editingId ? '编辑任务' : '新建任务'"
+             style="width: 640px" :mask-closable="false">
+      <n-form label-placement="left" label-width="92" size="small">
+        <n-form-item label="任务名称" required>
+          <n-input v-model:value="form.name" placeholder="如：每日经营简报" />
+        </n-form-item>
+        <n-form-item label="触发方式" required>
+          <n-radio-group v-model:value="form.trigger_type">
+            <n-radio value="cron">定时（cron）</n-radio>
+            <n-radio value="event">事件触发</n-radio>
+          </n-radio-group>
+        </n-form-item>
+        <n-form-item v-if="form.trigger_type === 'cron'" label="cron 表达式" required>
+          <n-input v-model:value="form.cron_expr" placeholder="分 时 日 月 周（服务器本地时间），如 0 9 * * 1-5" />
+          <div class="field-hint">
+            快捷：
+            <n-button text type="primary" size="tiny" @click="form.cron_expr = '0 9 * * *'">每天 9 点</n-button> ·
+            <n-button text type="primary" size="tiny" @click="form.cron_expr = '0 9 * * 1-5'">工作日 9 点</n-button> ·
+            <n-button text type="primary" size="tiny" @click="form.cron_expr = '0 * * * *'">每小时</n-button> ·
+            <n-button text type="primary" size="tiny" @click="form.cron_expr = '*/15 * * * *'">每 15 分钟</n-button>
+          </div>
+        </n-form-item>
+        <template v-if="form.trigger_type === 'event'">
+          <n-form-item label="事件标识" required>
+            <n-input v-model:value="form.event_key" placeholder="如 order.refunded" />
+          </n-form-item>
+          <n-form-item label="secret">
+            <n-input v-model:value="form.secret" placeholder="可选；配置后调用方需携带相同 secret" />
+          </n-form-item>
+          <n-form-item v-if="form.event_key" label="调用地址">
+            <code class="event-url">{{ eventUrlPreview }}</code>
+          </n-form-item>
+        </template>
+        <n-form-item label="执行员工" required>
+          <n-select v-model:value="form.employee_id" :options="employeeOptions"
+                    placeholder="选择数字员工" filterable />
+        </n-form-item>
+        <n-form-item label="任务指令" required>
+          <n-input v-model:value="form.prompt" type="textarea" :rows="4"
+                   placeholder="要执行的工作描述。可用占位符：{{now}} 当前时间；{{payload}} 事件数据（事件触发时）" />
+        </n-form-item>
+        <n-form-item label="运行身份">
+          <n-input v-model:value="form.run_as" placeholder="以哪个用户身份运行（影响记忆与会话归属），默认创建者" />
+        </n-form-item>
+        <n-form-item label="推送频道">
+          <n-select v-model:value="form.channel_id" :options="channelOptions"
+                    placeholder="不推送：结果仅落会话历史" clearable />
+          <div class="field-hint">选择配置了 outbound_webhook 的频道，任务结果会推送到外部 IM</div>
+        </n-form-item>
+      </n-form>
+      <template #footer>
+        <div class="modal-footer">
+          <n-button size="small" @click="showForm = false">取消</n-button>
+          <n-button size="small" type="primary" :loading="saving" @click="save">保存</n-button>
+        </div>
+      </template>
+    </n-modal>
+
+    <!-- 运行结果 -->
+    <n-modal v-model:show="showResult" preset="card" title="任务执行结果" style="width: 640px">
+      <div v-if="runResult" class="run-result">
+        <div class="run-meta">
+          <n-tag :type="runResult.status === 'ok' ? 'success' : 'error'" size="small">
+            {{ runResult.status === 'ok' ? '成功' : '失败' }}
+          </n-tag>
+          <span class="run-conv">会话：{{ runResult.conversation_id }}</span>
+        </div>
+        <div v-if="runResult.error" class="run-error">{{ runResult.error }}</div>
+        <pre class="run-reply">{{ runResult.reply || '（无输出）' }}</pre>
+      </div>
+      <template #footer>
+        <div class="modal-footer">
+          <n-button size="small" @click="showResult = false">关闭</n-button>
+          <n-button size="small" type="primary" @click="gotoConv">前往会话</n-button>
+        </div>
+      </template>
+    </n-modal>
+  </div>
+</template>
+
+<script setup>
+import { h, ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { NButton, NTag, NSwitch, NTooltip, useMessage } from 'naive-ui'
+import api from '../api.js'
+
+defineOptions({ name: 'AutomationView' })
+
+const router = useRouter()
+const message = useMessage()
+const loading = ref(false)
+const saving = ref(false)
+const items = ref([])
+const employees = ref([])
+const channels = ref([])
+const showForm = ref(false)
+const showResult = ref(false)
+const editingId = ref(null)
+const runResult = ref(null)
+const runningIds = ref(new Set())
+
+const form = ref({
+  name: '', trigger_type: 'cron', cron_expr: '', event_key: '', secret: '',
+  employee_id: null, prompt: '', run_as: '', channel_id: null, enabled: true,
+})
+
+const employeeOptions = computed(() =>
+  employees.value.map(e => ({ label: `${e.name}（${e.id}）`, value: e.id })))
+const channelOptions = computed(() =>
+  channels.value.map(c => ({ label: c.name, value: c.id })))
+const eventUrlPreview = computed(() =>
+  `${location.origin}/api/automations/events/${form.value.event_key || '<事件标识>'}`)
+
+function triggerText(row) {
+  if (row.trigger_type === 'cron') return row.cron_expr
+  return `${row.event_key}`
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [a, e, c] = await Promise.all([
+      api.get('/automations'),
+      api.get('/admin/employees'),
+      api.get('/im/channels'),
+    ])
+    items.value = a.data.items || []
+    employees.value = e.data || []
+    channels.value = c.data.items || []
+  } catch (err) {
+    message.error('加载失败：' + (err.response?.data?.detail || err.message))
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreate() {
+  editingId.value = null
+  form.value = { name: '', trigger_type: 'cron', cron_expr: '0 9 * * *', event_key: '',
+                 secret: '', employee_id: null, prompt: '', run_as: '', channel_id: null,
+                 enabled: true }
+  showForm.value = true
+}
+
+function openEdit(row) {
+  editingId.value = row.id
+  form.value = {
+    name: row.name, trigger_type: row.trigger_type, cron_expr: row.cron_expr,
+    event_key: row.event_key, secret: row.secret, employee_id: row.employee_id,
+    prompt: row.prompt, run_as: row.run_as, channel_id: row.channel_id || null,
+    enabled: row.enabled,
+  }
+  showForm.value = true
+}
+
+async function save() {
+  const f = form.value
+  if (!f.name.trim() || !f.prompt.trim() || !f.employee_id) {
+    message.warning('请填写任务名称、执行员工和任务指令')
+    return
+  }
+  if (f.trigger_type === 'cron' && !f.cron_expr.trim()) {
+    message.warning('请填写 cron 表达式')
+    return
+  }
+  if (f.trigger_type === 'event' && !f.event_key.trim()) {
+    message.warning('请填写事件标识')
+    return
+  }
+  saving.value = true
+  try {
+    const body = { ...f, channel_id: f.channel_id || '' }
+    if (editingId.value) await api.put(`/automations/${editingId.value}`, body)
+    else await api.post('/automations', body)
+    message.success('已保存')
+    showForm.value = false
+    await load()
+  } catch (err) {
+    message.error('保存失败：' + (err.response?.data?.detail || err.message))
+  } finally {
+    saving.value = false
+  }
+}
+
+async function toggleEnabled(row, v) {
+  try {
+    await api.put(`/automations/${row.id}`, { enabled: v })
+    row.enabled = v
+  } catch (err) {
+    row.enabled = !v
+    message.error('操作失败：' + (err.response?.data?.detail || err.message))
+  }
+}
+
+async function runNow(row) {
+  runningIds.value = new Set([...runningIds.value, row.id])
+  message.info(`正在运行「${row.name}」，请稍候…`)
+  try {
+    const { data } = await api.post(`/automations/${row.id}/run`)
+    runResult.value = data
+    showResult.value = true
+    await load()
+  } catch (err) {
+    message.error('运行失败：' + (err.response?.data?.detail || err.message))
+  } finally {
+    const s = new Set(runningIds.value)
+    s.delete(row.id)
+    runningIds.value = s
+  }
+}
+
+async function del(row) {
+  try {
+    await api.delete(`/automations/${row.id}`)
+    message.success('已删除')
+    await load()
+  } catch (err) {
+    message.error('删除失败：' + (err.response?.data?.detail || err.message))
+  }
+}
+
+function gotoConv() {
+  showResult.value = false
+  if (runResult.value?.conversation_id) {
+    router.push({ name: 'history' })
+  }
+}
+
+const columns = [
+  { title: '任务', key: 'name', width: 170,
+    render: r => h('div', { class: 'cell-name' }, [
+      h('div', { class: 'name' }, r.name),
+      r.last_status === 'error'
+        ? h('div', { class: 'err-hint', title: r.last_error }, '上次运行失败') : null,
+    ]) },
+  { title: '触发', key: 'trigger', width: 150,
+    render: r => h('div', { class: 'cell-trigger' }, [
+      h(NTag, { size: 'tiny', type: r.trigger_type === 'cron' ? 'info' : 'warning',
+                bordered: false }, { default: () => (r.trigger_type === 'cron' ? '定时' : '事件') }),
+      h('span', { class: 'expr', title: r.trigger_type === 'cron'
+        ? 'cron：分 时 日 月 周' : r.event_url || '' }, triggerText(r)),
+    ]) },
+  { title: '员工', key: 'employee_id', width: 120,
+    render: r => r.employee_id },
+  { title: '指令', key: 'prompt', ellipsis: { tooltip: true },
+    render: r => h('span', { class: 'prompt' }, r.prompt) },
+  { title: '上次运行', key: 'last_run_at', width: 190,
+    render: r => h('div', { class: 'cell-run' }, [
+      h('span', {}, r.last_run_at
+        ? `${r.last_run_at}（${runCountLabel(r)}）` : '未运行过'),
+      r.last_conv_id ? h(NButton, { text: true, type: 'primary', size: 'tiny',
+        onClick: () => router.push({ name: 'history' }) }, { default: () => '查看' }) : null,
+    ]) },
+  { title: '启用', key: 'enabled', width: 70,
+    render: r => h(NSwitch, { value: r.enabled, size: 'small',
+      onUpdateValue: v => toggleEnabled(r, v) }) },
+  { title: '操作', key: 'actions', width: 180,
+    render: r => h('div', { class: 'cell-actions' }, [
+      h(NTooltip, null, { trigger: () => h(NButton, {
+        size: 'tiny', secondary: true, loading: runningIds.value.has(r.id),
+        onClick: () => runNow(r) }, { default: () => '运行' }),
+        default: () => '立即运行一次（不影响定时计划）' }),
+      h(NButton, { size: 'tiny', secondary: true, onClick: () => openEdit(r) },
+        { default: () => '编辑' }),
+      h(NButton, { size: 'tiny', secondary: true, type: 'error', onClick: () => del(r) },
+        { default: () => '删除' }),
+    ]) },
+]
+
+function runCountLabel(r) {
+  const st = r.last_status === 'ok' ? '成功' : r.last_status === 'error' ? '失败' : r.last_status
+  return `${st}，共 ${r.run_count} 次`
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.auto-page { padding: 24px; height: 100%; overflow-y: auto; }
+.toolbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
+.intro-title { font-size: 14px; font-weight: 600; color: #334155; }
+.intro-sub { font-size: 12px; color: #94a3b8; margin-top: 3px; }
+.field-hint { font-size: 11px; color: #94a3b8; margin-top: 4px; }
+.event-url { font-size: 11px; background: #f1f5f9; border-radius: 6px; padding: 3px 8px; color: #475569; }
+.modal-footer { display: flex; justify-content: flex-end; gap: 8px; }
+.cell-name .name { font-weight: 500; color: #0f172a; }
+.cell-name .err-hint { font-size: 11px; color: #b91c1c; margin-top: 2px; }
+.cell-trigger { display: flex; align-items: center; gap: 6px; }
+.cell-trigger .expr { font-size: 12px; color: #475569; font-family: ui-monospace, monospace; }
+.prompt { font-size: 12px; color: #64748b; }
+.cell-run { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #64748b; }
+.cell-actions { display: flex; gap: 4px; }
+.run-result .run-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.run-conv { font-size: 12px; color: #64748b; font-family: ui-monospace, monospace; }
+.run-error { font-size: 12px; color: #b91c1c; background: #fef2f2; border-radius: 6px; padding: 8px 12px; margin-bottom: 10px; }
+.run-reply { font-size: 12px; color: #334155; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; white-space: pre-wrap; word-break: break-word; max-height: 320px; overflow: auto; margin: 0; }
+</style>

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,0 +1,171 @@
+"""自动化任务回归测试：cron 解析 / next_fire 计算 / CRUD / 抢占 / 模板渲染。"""
+from datetime import datetime
+
+from app import automations
+
+
+# ---- cron 解析与匹配 ----
+
+def test_cron_every_minute():
+    parsed = automations.parse_cron("* * * * *")
+    assert automations.cron_match(parsed, datetime(2026, 9, 2, 10, 30, 5))
+
+
+def test_cron_daily_at_9():
+    parsed = automations.parse_cron("0 9 * * *")
+    assert automations.cron_match(parsed, datetime(2026, 9, 2, 9, 0))
+    assert not automations.cron_match(parsed, datetime(2026, 9, 2, 9, 1))
+    assert not automations.cron_match(parsed, datetime(2026, 9, 2, 10, 0))
+
+
+def test_cron_step_and_range_and_list():
+    parsed = automations.parse_cron("*/15 9-11 1,15 * *")
+    assert automations.cron_match(parsed, datetime(2026, 9, 1, 10, 45))
+    assert not automations.cron_match(parsed, datetime(2026, 9, 1, 10, 40))  # 分钟不在 */15
+    assert not automations.cron_match(parsed, datetime(2026, 9, 2, 10, 45))  # 日不在 1,15
+    assert not automations.cron_match(parsed, datetime(2026, 9, 1, 12, 45))  # 时不在 9-11
+
+
+def test_cron_dow_sunday_is_0_or_7():
+    # 2026-09-06 是周日
+    for expr in ("* * * * 0", "* * * * 7"):
+        parsed = automations.parse_cron(expr)
+        assert automations.cron_match(parsed, datetime(2026, 9, 6, 8, 0))
+        assert not automations.cron_match(parsed, datetime(2026, 9, 7, 8, 0))  # 周一
+
+
+def test_cron_dom_dow_union_semantics():
+    # 日与周同时受限 -> 并集：1 号或每个周一（2026-09-07 是周一）
+    parsed = automations.parse_cron("0 0 1 * 1")
+    assert automations.cron_match(parsed, datetime(2026, 9, 7, 0, 0))   # 周一但非 1 号
+    assert automations.cron_match(parsed, datetime(2026, 10, 1, 0, 0))  # 1 号但非周一
+    assert not automations.cron_match(parsed, datetime(2026, 9, 8, 0, 0))
+
+
+def test_cron_invalid_expressions():
+    for bad in ("* * * *", "61 * * * *", "* 24 * * *", "* * 0 * *",
+                "*/0 * * * *", "5-2 * * * *", "a * * * *", "* * 31 2 *"):
+        assert automations.validate_cron(bad) != "", f"应判定非法: {bad}"
+    assert automations.validate_cron("*/5 * * * *") == ""
+    assert automations.validate_cron("0 9 * * 1-5") == ""
+
+
+def test_next_fire_basic():
+    after = datetime(2026, 9, 2, 10, 30)
+    nxt = automations.next_fire("0 9 * * *", after)
+    assert (nxt.year, nxt.month, nxt.day, nxt.hour, nxt.minute) == (2026, 9, 3, 9, 0)
+    # 紧随其后的分钟也能算（after 所在分钟不算，从下一分钟开始）
+    assert automations.next_fire("* * * * *", after) == datetime(2026, 9, 2, 10, 31)
+
+
+def test_next_fire_impossible_returns_none():
+    # 2 月 30 日不存在
+    assert automations.next_fire("0 0 30 2 *", datetime(2026, 1, 1)) is None
+
+
+# ---- CRUD 与调度语义 ----
+
+def _mk_cron(**kw):
+    base = dict(name="每日报表", trigger_type="cron", employee_id="xiaoshu",
+                prompt="汇总今日经营数据并输出简报", cron_expr="0 9 * * *")
+    base.update(kw)
+    return automations.create(**base)
+
+
+def test_create_cron_sets_next_fire():
+    auto = _mk_cron()
+    assert auto["trigger_type"] == "cron"
+    assert auto["next_fire_at"]  # 启用中的 cron 任务创建即排期
+    nxt = automations.next_fire("0 9 * * *", datetime.now())
+    assert auto["next_fire_at"] == nxt.strftime(automations.TS)
+
+
+def test_disable_clears_next_fire_and_enable_reschedules():
+    auto = _mk_cron()
+    off = automations.update(auto["id"], enabled=False)
+    assert off["enabled"] is False and off["next_fire_at"] is None
+    on = automations.update(auto["id"], enabled=True)
+    assert on["next_fire_at"]
+
+
+def test_update_cron_expr_reschedules():
+    auto = _mk_cron()
+    upd = automations.update(auto["id"], cron_expr="*/10 * * * *")
+    assert upd["cron_expr"] == "*/10 * * * *"
+    nxt = automations.next_fire("*/10 * * * *", datetime.now())
+    assert upd["next_fire_at"] == nxt.strftime(automations.TS)
+
+
+def test_due_crons_only_enabled_and_past():
+    past = _mk_cron(name="过期任务")
+    future = _mk_cron(name="未来任务", cron_expr="0 3 * * *")  # 明天凌晨 3 点
+    disabled = _mk_cron(name="停用任务", enabled=False)
+    # 把 past 的触发点手动拨到 1 小时前（模拟停机错过）
+    with automations._conn() as con:
+        con.execute("UPDATE automations SET next_fire_at=? WHERE id=?",
+                    (datetime.now().strftime(automations.TS), past["id"]))
+        con.commit()
+    due = automations.due_crons(datetime.now().strftime(automations.TS))
+    ids = {a["id"] for a in due}
+    assert past["id"] in ids
+    assert future["id"] not in ids
+    assert disabled["id"] not in ids
+
+
+def test_claim_next_cas_prevents_double_run():
+    auto = _mk_cron()
+    old = auto["next_fire_at"]
+    # 期望值不对（已被别人抢走）-> 抢占失败
+    assert automations.claim_next(auto["id"], "2099-01-01T00:00", "2099-01-02T00:00") is False
+    assert automations.get(auto["id"])["next_fire_at"] == old
+    # 期望值正确 -> 成功并写入新触发点
+    new_next = "2099-01-02T00:00"
+    assert automations.claim_next(auto["id"], old, new_next) is True
+    cur = automations.get(auto["id"])
+    assert cur["next_fire_at"] == new_next
+    assert cur["last_status"] == "running"
+
+
+def test_mark_result_updates_counters():
+    auto = _mk_cron()
+    automations.mark_result(auto["id"], "ok", "", "c_test_1")
+    cur = automations.get(auto["id"])
+    assert cur["last_status"] == "ok"
+    assert cur["last_conv_id"] == "c_test_1"
+    assert cur["run_count"] == 1
+
+
+def test_list_by_event_filters_enabled():
+    automations.create(name="退款事件", trigger_type="event", employee_id="xiaoshu",
+                       prompt="处理退款事件", event_key="order.refunded", secret="s1")
+    automations.create(name="退款事件停用", trigger_type="event", employee_id="xiaoshu",
+                       prompt="处理退款事件", event_key="order.refunded", enabled=False)
+    hits = automations.list_by_event("order.refunded")
+    assert len(hits) == 1 and hits[0]["name"] == "退款事件"
+    assert automations.list_by_event("no.such.event") == []
+
+
+def test_delete():
+    auto = _mk_cron()
+    assert automations.delete(auto["id"]) is True
+    assert automations.delete(auto["id"]) is False
+    assert automations.get(auto["id"]) is None
+
+
+# ---- 模板渲染 ----
+
+def test_render_prompt_placeholders():
+    out = automations.render_prompt("现在是 {{now}}，事件：{{payload}}",
+                                    payload={"order_id": "A1", "amount": 99})
+    assert "{{now}}" not in out and "{{payload}}" not in out
+    assert "A1" in out and "99" in out
+
+
+def test_render_prompt_appends_payload_when_no_placeholder():
+    out = automations.render_prompt("处理该事件", payload={"k": "v"})
+    assert "处理该事件" in out and "[事件数据]" in out and '"k": "v"' in out
+
+
+def test_render_prompt_without_payload():
+    out = automations.render_prompt("生成 {{now}} 的日报")
+    assert "{{now}}" not in out


### PR DESCRIPTION
## 变更说明

数字员工从「被动问答」升级为「主动执行」：补上**定时（cron）/ 事件（webhook）两类机器触发源 → 自动起 run → 结果落会话（可选推送外部 IM）**，覆盖每日经营简报、合同到期提醒、事件驱动处理等高价值场景。

### 新增
- **定时任务**：`automations` 表 + 调度器随应用 lifespan 启动（30s 扫描）；`next_fire_at` CAS 抢占防多实例/慢执行重入；停机错过的触发点只补跑一次；`AUTOMATIONS_DISABLED=1` 可关闭
- **事件触发**：`POST /api/automations/events/{event_key}` 即时触发监听任务；任务级 secret 鉴权；事件数据注入 `{{payload}}`（`{{now}}` 注入时间）；同步返回执行结果
- **执行引擎复用 `_stream_run`**：敏感词护栏、工具调用护栏、长期记忆、Trace、审批中断全部生效；每次触发产生完整会话，历史可见可回溯
- **前端「自动任务」管理页**（admin 侧边栏）：任务列表（触发/员工/指令/上次运行状态）、启停开关、cron 快捷模板、「立即运行」手动验收并查看回复
- **结果推送**：绑定 IM 频道后经 `outbound_webhook` 推送外部 IM
- **零新增依赖的 cron 解析器**（`*` `,` `-` `/`、`7=周日`、日/周并集语义）

### 修复
- traces 聚合 SQL 的 PG 方言 bug：`SUM(etype='llm')` → `SUM(CASE WHEN ... THEN 1 ELSE 0 END)`，修复每次 run 统计回写失败、trace 卡 running

### 版本
- v0.10.0（CHANGELOG / main.py / .env.example / README 已同步）

## 验证清单

- [x] `pytest tests/test_automations.py`：19 条全通过（cron 匹配/next_fire/非法表达式/CAS 抢占/CRUD/启停重排期/模板渲染）
- [x] 全量 pytest（除依赖运行服务与真实凭据的集成测试外全部通过）
- [x] `cd frontend && npx vite build` 通过
- [x] 端到端实测（PG 环境）：定时任务每 5 分钟自动抓取资讯落会话（3 次 run 全部 ok，trace 记录 llm_calls/tool_calls 正常）
- [x] 端到端实测：事件触发 `order.refunded`（含 payload）→ xiaoshu 生成完整处理建议，会话落库 admin 名下
- [x] `/health` 返回 version 0.10.0

## 合并注意

- 建议先合并 #21（v0.9.0），本 PR 再 rebase main 后合并，保持版本号连续
- 已知待办（后续 PR）：创建任务时员工校验未拦截已删除员工；删除用户时其名下自动任务的归属处理