### PR TITLE
chore: 升级 deepagents 0.7.5 → 0.7.13 + langgraph 1.2.9 → 1.2.11

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,9 +6,9 @@ python-dotenv==1.2.2
 pyyaml==6.0.3
 PyJWT==2.13.0
 bcrypt==5.0.0
-deepagents==0.7.5
+deepagents==0.7.13
 langchain-deepseek==1.1.0
-langgraph==1.2.9
+langgraph==1.2.11
 # PostgreSQL 后端（checkpointer + store + 连接；DB_BACKEND=postgres 时必需）
 langgraph-checkpoint-postgres==3.1.2
 psycopg[binary,pool]==3.3.4


### PR DESCRIPTION
## Summary

- `deepagents` 0.7.5 → 0.7.13（8 个小版本）
- `langgraph` 1.2.9 → 1.2.11

## 兼容性验证

- 现有 API 调用全部兼容：`create_deep_agent` / `CompositeBackend` / `StateBackend` / `LocalShellBackend` / `FilesystemBackend` / `create_file_data`
- 现有 langgraph 调用兼容：`StateGraph` / `interrupt` / `Command` / `get_config` / postgres & sqlite 的 Saver/Store

## Test plan

- [x] pytest 171/171 通过（catalog / ontology / analyst 全集）
- [x] API 兼容性脚本验证通过
- [ ] 启动服务手测：发起对话、审批、自动化任务触发等