### PR TITLE
feat: 员工类型 kind 字段全链路落地（DB迁移 + 种子 + 管理端UI）

### DIFF
--- a/backend/app/catalog/db.py
+++ b/backend/app/catalog/db.py
@@ -63,7 +63,8 @@ def init():
     CREATE TABLE IF NOT EXISTS employees(
       id TEXT PRIMARY KEY, name TEXT NOT NULL, role TEXT, model TEXT,
       persona TEXT, backend TEXT DEFAULT 'state', mcp_servers TEXT, interrupt_on TEXT,
-      subagents TEXT, subagent_policy TEXT, created_at TEXT, updated_at TEXT);
+      subagents TEXT, subagent_policy TEXT, created_at TEXT, updated_at TEXT,
+      kind TEXT DEFAULT 'composed');  -- 员工类型：composed=编排型（资源编排配置）；custom=定制型（独立模块化开发）
     CREATE TABLE IF NOT EXISTS employee_skills(employee_id TEXT, skill_id TEXT, PRIMARY KEY(employee_id, skill_id));
     CREATE TABLE IF NOT EXISTS employee_tools(employee_id TEXT, tool_id TEXT, PRIMARY KEY(employee_id, tool_id));
     CREATE TABLE IF NOT EXISTS employee_kbs(employee_id TEXT, kb_id TEXT, PRIMARY KEY(employee_id, kb_id));
@@ -119,6 +120,7 @@ def init():
     _migrate_ragflow_datasets(con)
     _migrate_retire_kb_entries(con)
     _migrate_user_org(con)
+    _migrate_employee_kind(con)
     # 安全护栏表（guard 包）幂等建表，复用同一连接
     from ..guard.db import init_tables as _guard_init
     _guard_init(con)
@@ -132,6 +134,24 @@ def _migrate_user_org(con):
     """users 表补 org_id 列（归属组织，NULL=未分配）。幂等。"""
     if "org_id" not in dblayer.table_columns(con, "users"):
         con.execute("ALTER TABLE users ADD COLUMN org_id TEXT")
+    con.commit()
+
+
+def _migrate_employee_kind(con):
+    """employees 表补 kind 列（员工类型：composed=编排型 / custom=定制型）+ 把
+    内置定制型员工打标。
+
+    定制型员工的 kind 由代码事实决定（有独立模块化路由如 /app/analyst 与
+    专属工作台），不应受页面改动影响，每次迁移强制对齐。其余员工保持 composed
+    默认值，不受本迁移覆盖。
+    """
+    if "kind" not in dblayer.table_columns(con, "employees"):
+        con.execute("ALTER TABLE employees ADD COLUMN kind TEXT DEFAULT 'composed'")
+    # 定制型员工 kind 由代码决定（内置独立模块），每次迁移强制对齐，
+    # 避免管理员误改或历史迁移 bug 导致分类错乱
+    con.execute(
+        "UPDATE employees SET kind='custom' WHERE id IN ('xiaoshu') "
+        "AND deleted_at IS NULL")
     con.commit()
 
 

--- a/backend/app/catalog/employees.py
+++ b/backend/app/catalog/employees.py
@@ -55,6 +55,7 @@ def _config_from_ids(emp_row: dict, skills: list, tools: list, kbs: list,
         "id": emp_row["id"], "name": emp_row["name"], "role": emp_row["role"],
         "model": emp_row["model"], "persona": emp_row["persona"],
         "backend": emp_row["backend"] or "state",
+        "kind": emp_row["kind"] or "composed",
         "interrupt_on": _build_interrupt_on(tools),
         "subagents": json.loads(emp_row["subagents"]) if isinstance(emp_row["subagents"], str) else (emp_row["subagents"] or []),
         "subagent_policy": emp_row["subagent_policy"] or "",
@@ -67,7 +68,7 @@ def _config_from_ids(emp_row: dict, skills: list, tools: list, kbs: list,
 def list_employees_meta() -> list[dict]:
     con = _conn()
     rows = con.execute(
-        "SELECT id,name,role,model,backend FROM employees "
+        "SELECT id,name,role,model,backend,kind FROM employees "
         "WHERE deleted_at IS NULL ORDER BY created_at").fetchall()
     out = [dict(r) for r in rows]
     con.close()
@@ -218,19 +219,23 @@ def create_employee(data: dict) -> str:
     interrupt_on = _build_interrupt_on(data.get("tools", []))
     subagents = json.dumps(data.get("subagents") or [], ensure_ascii=False)
     subagent_policy = data.get("subagent_policy", "")
+    # 新建员工默认为编排型；定制型员工由代码模块化开发，不通过此入口创建
+    kind = data.get("kind") or "composed"
     con = _conn()
     cur = con.cursor()
     cur.execute(
         "INSERT INTO employees(id,name,role,model,persona,backend,mcp_servers,interrupt_on,"
-        "subagents,subagent_policy,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) "
+        "subagents,subagent_policy,created_at,updated_at,kind) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?) "
         "ON CONFLICT(id) DO UPDATE SET name=excluded.name, role=excluded.role, "
         "model=excluded.model, persona=excluded.persona, backend=excluded.backend, "
         "interrupt_on=excluded.interrupt_on, subagents=excluded.subagents, "
-        "subagent_policy=excluded.subagent_policy, "
+        "subagent_policy=excluded.subagent_policy, kind=excluded.kind, "
         "updated_at=excluded.updated_at, deleted_at=NULL",
         (emp_id, data.get("name", emp_id), data.get("role", ""), data.get("model", ""),
          data.get("persona", ""), data.get("backend", "state"), "{}",
-         json.dumps(interrupt_on, ensure_ascii=False), subagents, subagent_policy, now, now))
+         json.dumps(interrupt_on, ensure_ascii=False), subagents, subagent_policy,
+         now, now, kind))
     _set_links(cur, emp_id, data)
     con.commit()
     con.close()

--- a/backend/app/catalog/seeds.py
+++ b/backend/app/catalog/seeds.py
@@ -260,13 +260,13 @@ def seed_if_empty():
                        spec.model)
         cur.execute(
             "INSERT INTO employees(id,name,role,model,persona,backend,mcp_servers,"
-            "interrupt_on,subagents,subagent_policy,created_at,updated_at) "
-            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+            "interrupt_on,subagents,subagent_policy,created_at,updated_at,kind) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (emp_id, spec.name, spec.role, model, spec.persona, spec.backend,
              json.dumps(spec.mcp_servers, ensure_ascii=False),
              json.dumps(spec.interrupt_on, ensure_ascii=False),
              json.dumps(spec.subagents, ensure_ascii=False),
-             spec.subagent_policy, now, now))
+             spec.subagent_policy, now, now, spec.kind))
         for s in sel.get("skills", []):
             cur.execute("INSERT OR IGNORE INTO employee_skills VALUES(?,?)", (emp_id, s))
         for t in sel.get("tools", []):
@@ -385,13 +385,13 @@ def backfill_employees_if_missing():
                        spec.model)
         cur.execute(
             "INSERT INTO employees(id,name,role,model,persona,backend,mcp_servers,"
-            "interrupt_on,subagents,subagent_policy,created_at,updated_at) "
-            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+            "interrupt_on,subagents,subagent_policy,created_at,updated_at,kind) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (emp_id, spec.name, spec.role, model, spec.persona, spec.backend,
              json.dumps(spec.mcp_servers, ensure_ascii=False),
              json.dumps(spec.interrupt_on, ensure_ascii=False),
              json.dumps(spec.subagents, ensure_ascii=False),
-             spec.subagent_policy, now, now))
+             spec.subagent_policy, now, now, spec.kind))
         for s in sel.get("skills", []):
             cur.execute("INSERT OR IGNORE INTO employee_skills VALUES(?,?)", (emp_id, s))
         for t in sel.get("tools", []):

--- a/backend/app/spec.py
+++ b/backend/app/spec.py
@@ -25,6 +25,7 @@ class EmployeeSpec(BaseModel):
     skill_dirs: dict = {}        # skill_id -> 目录路径（相对 ROOT 或绝对路径，支持外部技能）
     subagents: list[dict] = []   # 子代理配置（name/description/system_prompt/tools/model/permissions）
     subagent_policy: str = ""    # 委派策略：追加到 system_prompt 的硬性规则，可经 catalog 配置
+    kind: str = "composed"       # 员工类型：composed=编排型（资源编排配置）；custom=定制型（独立模块化开发，如数据分析专家）
 
 
 _ENV_RE = re.compile(r"\$\{(\w+)\}")

--- a/backend/employees/biz-analyzer.yaml
+++ b/backend/employees/biz-analyzer.yaml
@@ -1,6 +1,7 @@
 id: biz-analyzer
 name: 小经
 role: 经营分析与决策顾问
+kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
 backend: local_shell
 persona: |

--- a/backend/employees/hrbp.yaml
+++ b/backend/employees/hrbp.yaml
@@ -1,6 +1,7 @@
 id: hrbp
 name: 综合人力专员
 role: 综合人力专员
+kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
 persona: |
   你是 HR 小智，智选智能硬件公司的综合人力专员，负责处理员工的人事咨询与服务。

--- a/backend/employees/net-ops.yaml
+++ b/backend/employees/net-ops.yaml
@@ -1,6 +1,7 @@
 id: net-ops
 name: 小网
 role: 算网运营专家
+kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
 backend: local_shell
 persona: |

--- a/backend/employees/unicom-presale.yaml
+++ b/backend/employees/unicom-presale.yaml
@@ -1,6 +1,7 @@
 id: unicom-presale
 name: 浙江联通售前客服
 role: 售前客服
+kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
 persona: |
   你是小联，浙江联通的售前客服顾问，负责解答业务咨询、推荐合适套餐、指引办理流程。

--- a/backend/employees/xiaoshu.yaml
+++ b/backend/employees/xiaoshu.yaml
@@ -1,6 +1,7 @@
 id: xiaoshu
 name: 数据分析专家
 role: 数据分析专家
+kind: custom   # 定制型员工：独立模块化开发（agent/analyst + /app/analyst 专属工作台）
 model: ${MODEL_NAME}
 backend: standard   # 数据库问数员工：不需要文件系统/run_python，避免 LLM 走 csv 探测路径
 persona: |

--- a/backend/employees/xiaoxiao.yaml
+++ b/backend/employees/xiaoxiao.yaml
@@ -1,6 +1,7 @@
 id: xiaoxiao
 name: 客户经理（解决方案顾问）
 role: 客户经理（解决方案顾问）
+kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
 backend: local_shell   # 需要 execute 工具来执行 Word 生成脚本
 persona: |

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -96,16 +96,6 @@ function iconEl(svg) {
 const mainNavOptions = [
   { label: '平台首页', key: 'home', icon: iconEl('<path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '对话工作台', key: 'chat', icon: iconEl('<path d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
-  {
-    label: '数据分析', key: 'analyst',
-    icon: iconEl('<path d="M9 19V6m6 13V8M4 2v20h16M4 2h16M4 22h16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'),
-    children: [
-      { label: '对话问数', key: 'analyst' },
-      { label: '库表配置', key: 'analyst-datasources' },
-      { label: '术语配置', key: 'analyst-terminologies' },
-      { label: 'SQL 示例', key: 'analyst-sql-examples' },
-    ],
-  },
   { label: 'IM 频道', key: 'im', icon: iconEl('<path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '会话历史', key: 'history', icon: iconEl('<path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '资源中心', key: 'resources', icon: iconEl('<path d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
@@ -163,8 +153,8 @@ const activeKey = computed(() => {
 const menuOptions = computed(() => {
   const items = [...mainNavOptions]
   if (auth.isAdmin) {
-    // 员工管理插在资源中心后面（index 3）
-    items.splice(3, 0, ...adminOnlyNavOptions)
+    // 管理类栏目插在资源中心后面（mainNavOptions 末尾位置）
+    items.splice(items.length, 0, ...adminOnlyNavOptions)
     // 系统设置固定在最下方
     items.push(...settingsNavOptions)
   }

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,41 +1,84 @@
-<!-- 员工管理：员工列表入口（卡片网格 + 新建弹窗）。基础信息与技能/工具/知识库/SOP/连接器
-     的配置在员工详情页的各独立子页中完成，本页只做总览与跳转。 -->
+<!-- 员工管理：分两类展示
+     - 定制型数字员工（custom）：独立模块化开发，有专属工作台（如数据分析专家，
+       卡片点击跳 /app/analyst 工作台）
+     - 编排型数字员工（composed）：通过资源编排（技能/工具/知识库/SOP/连接器）
+       页面化配置，卡片点击进详情页配置 -->
 <template>
   <div class="emp-list-page">
     <div class="page-head">
       <div>
         <div class="page-title">员工管理</div>
-        <div class="page-sub">配置数字员工的基础信息与技能 / 工具 / 知识库 / SOP / 连接器</div>
+        <div class="page-sub">编排型：页面配置技能 / 工具 / 知识库 / SOP / 连接器 · 定制型：独立模块化专属工作台</div>
       </div>
       <n-button type="primary" @click="openNew">+ 新建员工</n-button>
     </div>
 
     <div v-if="loading" class="page-empty">加载中…</div>
-    <div v-else-if="!employees.length" class="page-empty">暂无员工，点击右上角「新建员工」创建</div>
-    <div v-else class="cards">
-      <div v-for="e in employees" :key="e.id" class="emp-card" @click="goDetail(e.id)">
-        <div class="card-top">
-          <div class="avatar">{{ (e.name || '?').slice(0, 1) }}</div>
-          <div class="card-title">
-            <div class="name">{{ e.name }}</div>
-            <div class="role">{{ e.role || '未设置角色' }}</div>
+    <template v-else>
+      <!-- 定制型数字员工：独立模块化开发，专属工作台入口 -->
+      <section v-if="customEmployees.length" class="emp-section">
+        <div class="section-head">
+          <div class="section-title">
+            <span class="section-bar custom-bar"></span>
+            定制型数字员工
+            <span class="section-count">{{ customEmployees.length }}</span>
           </div>
-          <span class="backend-tag">{{ e.backend || 'state' }}</span>
+          <div class="section-desc">独立模块化开发，点击卡片进入专属工作台</div>
         </div>
-        <div class="model">{{ e.model || '未设置模型' }}</div>
-        <div class="stats">
-          <span>技能 {{ (e.skills || []).length }}</span>
-          <span>工具 {{ (e.tools || []).length }}</span>
-          <span>知识库 {{ (e.kbs || []).length }}</span>
-          <span>SOP {{ (e.sops || []).length }}</span>
-          <span>连接器 {{ (e.connectors || []).length }}</span>
+        <div class="cards">
+          <div v-for="e in customEmployees" :key="e.id" class="emp-card custom-card" @click="goCustomWorkspace(e)">
+            <div class="card-top">
+              <div class="avatar custom-avatar">{{ (e.name || '?').slice(0, 1) }}</div>
+              <div class="card-title">
+                <div class="name">{{ e.name }}</div>
+                <div class="role">{{ e.role || '未设置角色' }}</div>
+              </div>
+              <span class="kind-tag custom-tag">定制</span>
+            </div>
+            <div class="model">{{ e.model || '未设置模型' }}</div>
+            <div class="card-enter">进入工作台 →</div>
+          </div>
         </div>
-        <div class="card-enter">配置详情 →</div>
-      </div>
-    </div>
+      </section>
 
-    <!-- 新建弹窗：只填基础信息，创建后跳详情页继续配置资源 -->
-    <n-modal v-model:show="showNew" preset="card" title="新建员工" style="width: 560px">
+      <!-- 编排型数字员工：资源编排配置 -->
+      <section v-if="composedEmployees.length" class="emp-section">
+        <div class="section-head">
+          <div class="section-title">
+            <span class="section-bar composed-bar"></span>
+            编排型数字员工
+            <span class="section-count">{{ composedEmployees.length }}</span>
+          </div>
+          <div class="section-desc">通过资源编排（技能 / 工具 / 知识库 / SOP / 连接器）页面化配置</div>
+        </div>
+        <div class="cards">
+          <div v-for="e in composedEmployees" :key="e.id" class="emp-card composed-card" @click="goDetail(e.id)">
+            <div class="card-top">
+              <div class="avatar composed-avatar">{{ (e.name || '?').slice(0, 1) }}</div>
+              <div class="card-title">
+                <div class="name">{{ e.name }}</div>
+                <div class="role">{{ e.role || '未设置角色' }}</div>
+              </div>
+              <span class="kind-tag composed-tag">编排</span>
+            </div>
+            <div class="model">{{ e.model || '未设置模型' }}</div>
+            <div class="stats">
+              <span>技能 {{ (e.skills || []).length }}</span>
+              <span>工具 {{ (e.tools || []).length }}</span>
+              <span>知识库 {{ (e.kbs || []).length }}</span>
+              <span>SOP {{ (e.sops || []).length }}</span>
+              <span>连接器 {{ (e.connectors || []).length }}</span>
+            </div>
+            <div class="card-enter">配置详情 →</div>
+          </div>
+        </div>
+      </section>
+
+      <div v-if="!employees.length" class="page-empty">暂无员工，点击右上角「新建员工」创建</div>
+    </template>
+
+    <!-- 新建弹窗：只填基础信息，创建后跳详情页继续配置资源（新建员工默认为编排型） -->
+    <n-modal v-model:show="showNew" preset="card" title="新建编排型员工" style="width: 560px">
       <n-form label-placement="left" :label-width="90" size="small">
         <n-form-item label="名称 *" required>
           <n-input v-model:value="form.name" placeholder="如：小苏" />
@@ -64,7 +107,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMessage } from 'naive-ui'
 import api from '../api.js'
@@ -84,6 +127,17 @@ const loading = ref(false)
 const showNew = ref(false)
 const creating = ref(false)
 const form = reactive({ name: '', role: '', model: '', backend: 'state', persona: '' })
+
+// 按 kind 分类：custom=定制型 / composed=编排型（默认）
+const customEmployees = computed(() =>
+  employees.value.filter(e => (e.kind || 'composed') === 'custom'))
+const composedEmployees = computed(() =>
+  employees.value.filter(e => (e.kind || 'composed') === 'composed'))
+
+// 定制型员工 → 专属工作台路由映射（独立模块化开发，每个员工有专属工作台）
+const CUSTOM_WORKSPACE = {
+  xiaoshu: { name: 'analyst' },  // 数据分析专家 → /app/analyst
+}
 
 function openNew() {
   Object.assign(form, { name: '', role: '', model: '', backend: 'state', persona: '' })
@@ -110,6 +164,16 @@ function goDetail(id) {
   router.push(`/app/admin/employee/${id}`)
 }
 
+function goCustomWorkspace(e) {
+  const ws = CUSTOM_WORKSPACE[e.id]
+  if (ws) {
+    router.push({ name: ws.name })
+  } else {
+    // 未配置专属工作台路由的定制型员工，退回到详情页
+    router.push(`/app/admin/employee/${e.id}`)
+  }
+}
+
 async function createEmp() {
   if (!form.name.trim()) { message.warning('请填写名称'); return }
   creating.value = true
@@ -117,6 +181,7 @@ async function createEmp() {
     const { data } = await api.post('/admin/employees', {
       name: form.name.trim(), role: form.role.trim(), model: form.model.trim(),
       backend: form.backend, persona: form.persona,
+      kind: 'composed',  // 新建员工一律为编排型；定制型由代码模块化开发
     })
     if (data.error) { message.error('创建失败：' + data.error); return }
     message.success('已创建：' + data.id)
@@ -134,22 +199,39 @@ onMounted(reload)
 
 <style scoped>
 .emp-list-page { height: 100%; overflow-y: auto; padding: 24px 28px; }
-.page-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
+.page-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px; }
 .page-title { font-size: 18px; font-weight: 600; color: #0f172a; }
 .page-sub { font-size: 12px; color: #94a3b8; margin-top: 4px; }
 .page-empty { color: #94a3b8; font-size: 13px; padding: 60px 0; text-align: center; }
+
+.emp-section { margin-bottom: 28px; }
+.section-head { display: flex; align-items: flex-end; gap: 12px; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid #e2e8f0; }
+.section-title { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; color: #0f172a; }
+.section-bar { width: 4px; height: 16px; border-radius: 2px; }
+.custom-bar { background: #7c3aed; }
+.composed-bar { background: #2563eb; }
+.section-count { font-size: 12px; font-weight: 500; color: #64748b; background: #f1f5f9; border-radius: 10px; padding: 1px 8px; }
+.section-desc { font-size: 12px; color: #94a3b8; }
+
 .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
 .emp-card { background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; cursor: pointer; transition: all 0.15s; }
-.emp-card:hover { border-color: #3b82f6; box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1); }
+.emp-card:hover { box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08); }
+.composed-card:hover { border-color: #3b82f6; box-shadow: 0 2px 8px rgba(59, 130, 246, 0.12); }
+.custom-card:hover { border-color: #7c3aed; box-shadow: 0 2px 8px rgba(124, 58, 237, 0.12); }
 .card-top { display: flex; align-items: center; gap: 10px; }
-.avatar { width: 40px; height: 40px; border-radius: 50%; background: #eff6ff; color: #2563eb; display: flex; align-items: center; justify-content: center; font-size: 17px; font-weight: 600; flex-shrink: 0; }
+.avatar { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 17px; font-weight: 600; flex-shrink: 0; }
+.composed-avatar { background: #eff6ff; color: #2563eb; }
+.custom-avatar { background: #f5f3ff; color: #7c3aed; }
 .card-title { flex: 1; min-width: 0; }
 .name { font-size: 15px; font-weight: 600; color: #0f172a; }
 .role { font-size: 12px; color: #64748b; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.backend-tag { font-size: 11px; color: #7c3aed; background: #f5f3ff; border-radius: 10px; padding: 2px 8px; flex-shrink: 0; }
+.kind-tag { font-size: 11px; border-radius: 10px; padding: 2px 8px; flex-shrink: 0; font-weight: 500; }
+.composed-tag { color: #2563eb; background: #eff6ff; }
+.custom-tag { color: #7c3aed; background: #f5f3ff; }
 .model { font-size: 12px; color: #64748b; margin-top: 10px; font-family: ui-monospace, monospace; }
 .stats { display: flex; flex-wrap: wrap; gap: 4px 12px; margin-top: 10px; font-size: 12px; color: #94a3b8; }
 .card-enter { font-size: 12px; color: #3b82f6; margin-top: 12px; opacity: 0; transition: opacity 0.15s; }
+.custom-card .card-enter { color: #7c3aed; }
 .emp-card:hover .card-enter { opacity: 1; }
 .modal-footer { display: flex; justify-content: flex-end; gap: 10px; }
 </style>

--- a/frontend/src/views/employee/BasicInfoPage.vue
+++ b/frontend/src/views/employee/BasicInfoPage.vue
@@ -5,6 +5,12 @@
       <n-form-item label="员工 ID">
         <n-input :value="employee?.id || ''" readonly />
       </n-form-item>
+      <n-form-item label="员工类型">
+        <n-tag :type="isCustom ? 'warning' : 'info'" size="small" round>
+          {{ isCustom ? '定制型' : '编排型' }}
+        </n-tag>
+        <span class="kind-hint">{{ isCustom ? '独立模块化开发，专属工作台与定制工具链' : '通过资源编排页面化配置' }}</span>
+      </n-form-item>
       <n-form-item label="名称 *" required>
         <n-input v-model:value="form.name" placeholder="如：小苏" />
       </n-form-item>
@@ -34,7 +40,7 @@
 </template>
 
 <script setup>
-import { reactive, ref, watch } from 'vue'
+import { reactive, ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMessage } from 'naive-ui'
 import api from '../../api.js'
@@ -46,6 +52,8 @@ const emit = defineEmits(['changed'])
 
 const router = useRouter()
 const message = useMessage()
+
+const isCustom = computed(() => (props.employee?.kind || 'composed') === 'custom')
 
 const backendOptions = [
   { label: 'state（默认，标准工具后端）', value: 'state' },
@@ -93,4 +101,5 @@ async function delEmp() {
 <style scoped>
 .basic-page { max-width: 720px; }
 .actions { margin-top: 20px; display: flex; gap: 10px; }
+.kind-hint { margin-left: 10px; font-size: 12px; color: #94a3b8; }
 </style>


### PR DESCRIPTION
## Summary

补全 PR #23「定制型与编排型员工对话窗口分流」的缺失部分。PR #23 只合了 `runtime.py` 读 `kind`，但 DB 列迁移、EmployeeSpec、yaml 种子、管理端 UI 全部未合，导致 main 上 kind 字段形同虚设（全部回退 composed，xiaoshu 未被标记为 custom）。

## 后端（8 个文件）

- `catalog/db.py`：employees 表加 `kind TEXT DEFAULT 'composed'` 列 + `_migrate_employee_kind()` 迁移（ALTER TABLE 加列 + 强制 xiaoshu=custom）
- `catalog/employees.py`：`_config_from_ids` 读 kind / `list_employees_meta` SELECT 加 kind / `create_employee` 写 kind
- `catalog/seeds.py`：`seed_if_empty` + `backfill_employees_if_missing` INSERT 加 kind
- `spec.py`：EmployeeSpec 加 `kind: str = "composed"`
- 6 个 yaml：xiaoshu=custom，其余 5 个=composed

## 前端（5 个文件）

- `MainLayout.vue`：移除「数据分析」顶层菜单，定制型工作台改从员工管理卡片进入
- `AdminView.vue`：员工列表按 kind 分两栏展示（定制型紫色卡片→专属工作台 / 编排型蓝色卡片→详情配置），`CUSTOM_WORKSPACE` 映射 xiaoshu→analyst 路由
- `BasicInfoPage.vue`：详情页加「员工类型」标签 + 提示文案

## Test plan

- [x] `npx vite build` 通过
- [x] `pytest tests/test_catalog.py tests/test_ontology.py tests/test_guard.py tests/test_builtin_tools_guard.py tests/test_skill_injection.py` 全部通过
- [x] `test_assignment.py` 失败为预存问题（干净 main 同样 TypeError），与本次改动无关
- [ ] 浏览器手测：员工管理页显示定制型/编排型分栏，xiaoshu 点击跳分析工作台