### PR TITLE
feat: OpenSandbox 沙箱执行环境基础设施（按会话路由，默认关闭）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ LOG_LEVEL=INFO
 # SQLite 数据目录；容器部署挂载卷后改为 /app/data。本地留空=项目根。
 # APP_DATA_DIR=/app/data
 # 版本号（/health 与日志会打印），便于多实例时定位。
-APP_VERSION=0.10.0
+APP_VERSION=0.12.0
 
 # ===== 数据库后端 =====
 # postgres（默认）：连接 PostgreSQL，每个业务库一个 database（catalog/conversations/
@@ -46,3 +46,27 @@ RAGFLOW_BASE_URL=http://localhost
 RAGFLOW_API_KEY=ragflow-your-api-key
 # 逗号分隔的 dataset id；留空则检索该 key 可见的全部 dataset。
 RAGFLOW_DATASET_IDS=
+
+# ===== OpenSandbox 沙箱执行环境 =====
+# 总开关：置 1 后 backend=sandbox 的员工（execute/文件工具）在沙箱容器内执行；
+# 留空/0 时回退宿主机 LocalShellBackend（测试与未部署 server 的环境）。
+# SANDBOX_ENABLED=1
+# server 地址（本地裸跑默认 localhost:8090；app 也跑容器时用 opensandbox-server:8090）
+SANDBOX_DOMAIN=localhost:8090
+SANDBOX_PROTOCOL=http
+# server 配置了 api_key 时填写（生产建议开启，去掉 server 的 OPENSANDBOX_INSECURE_SERVER）
+# SANDBOX_API_KEY=
+# 沙箱镜像（需预装 pandas/duckdb/matplotlib/openpyxl/python-docx，见 sandbox/image/Dockerfile）
+SANDBOX_IMAGE=uniemployee/sandbox:py312-data
+# **docker 宿主机**上数据目录的绝对路径（server 通过 docker.sock 挂载，按容器外路径解析）：
+#   SANDBOX_HOST_DATA     = workspace/data 的宿主机路径（按用户 subPath 读写挂到沙箱 /data）
+#   SANDBOX_HOST_DATASETS = workspace/datasets 的宿主机路径（共享数据集，只读挂到 /datasets）
+# 同时需在 server config.toml 的 [storage] allowed_host_paths 放行这两个前缀。
+# SANDBOX_HOST_DATA=/Users/wrg/Important/UniEmployee/workspace/data
+# SANDBOX_HOST_DATASETS=/Users/wrg/Important/UniEmployee/workspace/datasets
+# 沙箱空闲 TTL（分钟，到期 server 自动回收）与单命令超时（秒）
+SANDBOX_TTL_MINUTES=30
+SANDBOX_CMD_TIMEOUT=1800
+# 单沙箱资源上限
+SANDBOX_CPU=1
+SANDBOX_MEMORY=2Gi

--- a/backend/app/catalog/db.py
+++ b/backend/app/catalog/db.py
@@ -131,6 +131,9 @@ def init():
     # AI 模型配置表幂等建表，复用同一连接
     from .ai_models import init_tables as _ai_models_init
     _ai_models_init(con)
+    # 沙箱会话映射表（sandbox_mgr）幂等建表，复用同一连接
+    from ..sandbox_mgr import init_tables as _sandbox_init
+    _sandbox_init(con)
     con.close()
 
 

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -31,6 +31,7 @@ from app.workflows.refund import make_start_refund
 from app.agent.analyst.tools.sql_tools import ANALYST_SQL_TOOLS
 from app.agent.analyst.fileqa.tools import ANALYST_FILE_TOOLS
 from app.paths import PROJECT_ROOT, WORKSPACE_DATA
+from app.sandbox_mgr import RoutingSandboxBackend, enabled as sandbox_enabled
 
 ROOT = Path(__file__).resolve().parent.parent
 VENV_BIN = str(ROOT / ".venv" / "bin")
@@ -428,19 +429,33 @@ def sops_namespace(user_id: str | None, emp_id: str) -> tuple[str, ...]:
     return (user_id or "default", emp_id)
 
 
+def _local_shell_backend() -> LocalShellBackend:
+    """宿主机本地 shell backend（local_shell 员工，或 sandbox 开关未开时的回退）。
+
+    virtual_mode=False：execute 是真实 shell（cwd=PROJECT_ROOT），输出会暴露真实绝对路径；
+    若 virtual_mode=True，模型用这些绝对路径调用 write_file 会被 _resolve_path 当成虚拟路径
+    拼到 root_dir 下，产生 PROJECT_ROOT/<主机绝对路径> 镜像目录（曾引发文件落错位置的线上事故）。
+    关掉后绝对路径按字面落位，与 execute 语义一致。/data/ 等虚拟路由不受影响。
+    """
+    return LocalShellBackend(
+        root_dir=str(PROJECT_ROOT),
+        virtual_mode=False,
+        env={"PATH": f"{VENV_BIN}:{os.environ.get('PATH', '/usr/bin:/bin')}"},
+        inherit_env=True,
+    )
+
+
 def build_backends(spec: EmployeeSpec, store, user_id: str | None = None):
     """构造 CompositeBackend：默认后端 + /data、/skills、/memories、/sops 路由。"""
     if spec.backend == "local_shell":
-        # virtual_mode=False：execute 是真实 shell（cwd=PROJECT_ROOT），输出会暴露真实绝对路径；
-        # 若 virtual_mode=True，模型用这些绝对路径调用 write_file 会被 _resolve_path 当成虚拟路径
-        # 拼到 root_dir 下，产生 PROJECT_ROOT/<主机绝对路径> 镜像目录（曾引发文件落错位置的线上事故）。
-        # 关掉后绝对路径按字面落位，与 execute 语义一致。/data/ 等虚拟路由不受影响。
-        default_backend = LocalShellBackend(
-            root_dir=str(PROJECT_ROOT),
-            virtual_mode=False,
-            env={"PATH": f"{VENV_BIN}:{os.environ.get('PATH', '/usr/bin:/bin')}"},
-            inherit_env=True,
-        )
+        default_backend = _local_shell_backend()
+    elif spec.backend == "sandbox":
+        # sandbox 员工：execute/fs 工具进 OpenSandbox 沙箱（按会话路由，见 sandbox_mgr）。
+        # 开关未置 1（测试/开发/未部署 server）回退宿主机 LocalShellBackend，零行为变化。
+        if sandbox_enabled():
+            default_backend = RoutingSandboxBackend()
+        else:
+            default_backend = _local_shell_backend()
     else:
         default_backend = StateBackend()
     return CompositeBackend(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,12 +152,21 @@ async def health():
             dbs[name] = "ok"
         except Exception as e:
             dbs[name] = f"error: {e}"
-    all_ok = all(v == "ok" for v in dbs.values())
+    # OpenSandbox 沙箱服务探活（未启用时 disabled，不影响整体状态）
+    sandbox_status = "disabled"
+    try:
+        from app import sandbox_mgr
+        if sandbox_mgr.enabled():
+            sandbox_status = "ok" if sandbox_mgr.manager.ping() else "error: unreachable"
+    except Exception as e:
+        sandbox_status = f"error: {type(e).__name__}: {e}"
+    all_ok = all(v == "ok" for v in dbs.values()) and not sandbox_status.startswith("error")
     return {
         "status": "ok" if all_ok else "degraded",
         "version": APP_VERSION,
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "databases": dbs,
+        "sandbox": sandbox_status,
     }
 
 

--- a/backend/app/sandbox_mgr.py
+++ b/backend/app/sandbox_mgr.py
@@ -1,0 +1,382 @@
+"""OpenSandbox 沙箱执行环境（基础设施层）。
+
+架构（详见 .trae/documents/opensandbox_integration_plan.md）：
+
+- SandboxManager：按**会话**（langgraph thread_id）管理沙箱生命周期。
+  内存缓存 + catalog 库 sandbox_sessions 表持久化 thread→sandbox_id 映射
+  （服务重启后可 connect 重连），每次取用 best-effort renew 续租 TTL。
+- RoutingSandboxBackend：deepagents SandboxBackendProtocol 实现。agent 按
+  (员工, 用户) 编译并缓存，backend 实例编译期固定；本代理在每次工具调用时
+  从 langgraph config 取 thread_id/user_id，路由到该会话专属的
+  OpenSandboxBackend（ls/read_file/write_file/execute 等全部落沙箱容器）。
+
+启用方式：环境变量 SANDBOX_ENABLED=1。未启用时 compiler.build_backends
+回退 LocalShellBackend，本模块不发起任何网络请求（opensandbox 包全部延迟
+导入）。沙箱创建/连接失败时 acquire 抛 RuntimeError（中文明确提示），
+**不回退宿主机执行**——回退等于安全机制失效。
+
+server 侧部署依赖（非本仓库代码）：
+- OpenSandbox server config.toml 的 [storage] allowed_host_paths 放行
+  SANDBOX_HOST_DATA / SANDBOX_HOST_DATASETS 两个宿主机目录前缀；
+- 沙箱镜像需预装 pandas/duckdb/matplotlib/openpyxl/python-docx。
+"""
+import os
+import threading
+import time
+import urllib.request
+from datetime import timedelta
+
+from deepagents.backends.protocol import SandboxBackendProtocol
+
+# ---- 环境变量配置 ----
+
+# 宿主机 workspace/data 的绝对路径（沙箱 server 通过 docker.sock 起容器，
+# hostPath 解析在 **docker 宿主机**上，不是 app 容器内路径）。
+# 宿主机 workspace/datasets 的绝对路径（共享数据集，只读挂载到 /datasets）。
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def enabled() -> bool:
+    """沙箱开关。SANDBOX_ENABLED=1/true/yes 开启。"""
+    return _env("SANDBOX_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+# ---- 持久化表（挂 catalog 库，随 catalog.init 幂等建表）----
+
+def init_tables(con=None):
+    """sandbox_sessions：thread_id → sandbox_id 映射。
+
+    服务重启后凭此重连仍存活的沙箱；沙箱 TTL 过期被 server 回收后，
+    重连失败即删除映射并新建。
+    """
+    own = con is None
+    if own:
+        from .catalog.db import _conn
+        con = _conn()
+    con.executescript("""
+    CREATE TABLE IF NOT EXISTS sandbox_sessions(
+      thread_id TEXT PRIMARY KEY,
+      sandbox_id TEXT NOT NULL,
+      user_id TEXT,
+      created_at TEXT,
+      updated_at TEXT);
+    """)
+    con.commit()
+    if own:
+        con.close()
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _load_session(thread_id: str) -> str | None:
+    from .catalog.db import _conn
+    con = _conn()
+    try:
+        row = con.execute(
+            "SELECT sandbox_id FROM sandbox_sessions WHERE thread_id=?",
+            (thread_id,)).fetchone()
+        return row["sandbox_id"] if row else None
+    finally:
+        con.close()
+
+
+def _save_session(thread_id: str, sandbox_id: str, user_id: str) -> None:
+    from .catalog.db import _conn
+    con = _conn()
+    try:
+        con.execute(
+            "INSERT INTO sandbox_sessions(thread_id,sandbox_id,user_id,created_at,updated_at) "
+            "VALUES(?,?,?,?,?) "
+            "ON CONFLICT(thread_id) DO UPDATE SET sandbox_id=excluded.sandbox_id, "
+            "user_id=excluded.user_id, updated_at=excluded.updated_at",
+            (thread_id, sandbox_id, user_id, _now(), _now()))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _drop_session(thread_id: str) -> None:
+    from .catalog.db import _conn
+    con = _conn()
+    try:
+        con.execute("DELETE FROM sandbox_sessions WHERE thread_id=?", (thread_id,))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _connection_config():
+    """构造 OpenSandbox 连接配置（延迟导入 opensandbox）。"""
+    from opensandbox.config.connection_sync import ConnectionConfigSync
+    return ConnectionConfigSync(
+        domain=_env("SANDBOX_DOMAIN", "localhost:8090"),
+        protocol=_env("SANDBOX_PROTOCOL", "http"),
+        api_key=_env("SANDBOX_API_KEY") or None,
+    )
+
+
+class _Entry:
+    """一个会话对应的沙箱句柄缓存。"""
+
+    def __init__(self, backend, sandbox):
+        self.backend = backend   # OpenSandboxBackend（deepagents backend）
+        self.sandbox = sandbox   # SandboxSync（SDK 句柄）
+
+
+class SandboxManager:
+    """按会话获取/复用/回收沙箱（单例，线程安全）。"""
+
+    def __init__(self):
+        self._cache: dict[str, _Entry] = {}
+        self._locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    # -- 配置（读环境变量，可被测试 monkeypatch）--
+
+    @property
+    def ttl_minutes(self) -> int:
+        return int(_env("SANDBOX_TTL_MINUTES", "30") or "30")
+
+    @property
+    def cmd_timeout(self) -> int:
+        """沙箱内单条命令默认超时（秒），传给 OpenSandboxBackend。"""
+        return int(_env("SANDBOX_CMD_TIMEOUT", "1800") or "1800")
+
+    @property
+    def image(self) -> str:
+        return _env("SANDBOX_IMAGE", "uniemployee/sandbox:py312-data")
+
+    # -- 对外接口 --
+
+    def acquire(self, *, thread_id: str, user_id: str | None):
+        """获取会话专属沙箱 backend（OpenSandboxBackend）。
+
+        命中缓存 → renew 续租；沙箱已死（TTL 过期/被回收）→ 丢弃重建。
+        未命中 → 先按库中 sandbox_id 尝试 connect 重连，失败再 create。
+        任何创建/连接失败抛 RuntimeError，不回退宿主机。
+        """
+        if not enabled():
+            raise RuntimeError(
+                "沙箱执行环境未启用（SANDBOX_ENABLED 未置 1），无法执行沙箱操作。"
+                "请联系管理员启用 OpenSandbox 集成。")
+        if not thread_id:
+            raise RuntimeError("沙箱后端只能在会话运行时调用：运行时上下文缺少 thread_id。")
+        uid = user_id or "default"
+
+        entry = self._cache.get(thread_id)
+        if entry is not None:
+            try:
+                self._renew(entry.sandbox)
+                return entry.backend
+            except Exception as e:
+                # 沙箱已死（TTL 过期/server 重启被回收）→ 丢弃走重建
+                print(f"[sandbox] 会话 {thread_id} 沙箱续租失败，丢弃重建："
+                      f"{type(e).__name__}: {e}")
+                self._discard(thread_id)
+
+        with self._lock_for(thread_id):
+            # 双检：等锁期间可能已被其他线程创建
+            entry = self._cache.get(thread_id)
+            if entry is not None:
+                return entry.backend
+
+            sandbox = None
+            sid = _load_session(thread_id)
+            if sid:
+                try:
+                    sandbox = self._connect(sid)
+                except Exception as e:
+                    print(f"[sandbox] 会话 {thread_id} 重连沙箱 {sid} 失败，将新建："
+                          f"{type(e).__name__}: {e}")
+                    _drop_session(thread_id)
+            if sandbox is None:
+                sandbox = self._create(uid=uid, thread_id=thread_id)
+                _save_session(thread_id, sandbox.id, uid)
+                print(f"[sandbox] 会话 {thread_id} 新建沙箱 {sandbox.id}（uid={uid}）")
+            else:
+                print(f"[sandbox] 会话 {thread_id} 重连沙箱 {sandbox.id} 成功")
+
+            backend = self._wrap(sandbox)
+            self._cache[thread_id] = _Entry(backend, sandbox)
+            return backend
+
+    def kill_thread(self, thread_id: str) -> None:
+        """best-effort 销毁会话沙箱（会话删除/管理钩子用；TTL 兜底也会自动回收）。"""
+        entry = self._cache.pop(thread_id, None)
+        if entry is not None:
+            try:
+                self._kill(entry.sandbox)
+            except Exception as e:
+                print(f"[sandbox] kill {thread_id} 失败（忽略，TTL 兜底）："
+                      f"{type(e).__name__}: {e}")
+        _drop_session(thread_id)
+
+    def ping(self) -> bool:
+        """探活 OpenSandbox server（短超时，供 /health）。未启用返回 False。"""
+        if not enabled():
+            return False
+        url = f"{_env('SANDBOX_PROTOCOL', 'http')}://{_env('SANDBOX_DOMAIN', 'localhost:8090')}/health"
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                return 200 <= resp.status < 300
+        except Exception:
+            return False
+
+    # -- SDK 薄封装（测试可 monkeypatch）--
+
+    def _create(self, *, uid: str, thread_id: str):
+        """新建沙箱：/data 按用户 subPath 读写挂载，/datasets 只读挂载。"""
+        from opensandbox import SandboxSync
+        from opensandbox.models.sandboxes import Host, Volume
+
+        host_data = _env("SANDBOX_HOST_DATA")
+        if not host_data:
+            raise RuntimeError(
+                "沙箱已启用但未配置 SANDBOX_HOST_DATA"
+                "（docker 宿主机上 workspace/data 目录的绝对路径）。")
+        volumes = [
+            Volume(
+                name="data",
+                host=Host(path=host_data),
+                mount_path="/data",
+                read_only=False,
+                # subPath 限定沙箱只能看到本用户目录（多租户隔离）
+                sub_path=uid,
+            ),
+        ]
+        host_datasets = _env("SANDBOX_HOST_DATASETS")
+        if host_datasets:
+            volumes.append(Volume(
+                name="datasets",
+                host=Host(path=host_datasets),
+                mount_path="/datasets",
+                read_only=True,
+            ))
+        return SandboxSync.create(
+            self.image,
+            timeout=timedelta(minutes=self.ttl_minutes),
+            ready_timeout=timedelta(seconds=60),
+            volumes=volumes,
+            resource={"cpu": _env("SANDBOX_CPU", "1"),
+                      "memory": _env("SANDBOX_MEMORY", "2Gi")},
+            metadata={"app": "uniemployee", "thread": thread_id, "uid": uid},
+            connection_config=_connection_config(),
+        )
+
+    def _connect(self, sandbox_id: str):
+        """按 sandbox_id 重连已存在的沙箱（带健康检查，失败抛异常）。"""
+        from opensandbox import SandboxSync
+        return SandboxSync.connect(
+            sandbox_id,
+            connection_config=_connection_config(),
+            connect_timeout=timedelta(seconds=10),
+        )
+
+    def _wrap(self, sandbox):
+        """把 SDK 句箱包装为 deepagents backend。"""
+        from langchain_opensandbox import OpenSandboxBackend
+        return OpenSandboxBackend(sandbox=sandbox, timeout=self.cmd_timeout)
+
+    def _renew(self, sandbox) -> None:
+        sandbox.renew(timedelta(minutes=self.ttl_minutes))
+
+    def _kill(self, sandbox) -> None:
+        sandbox.kill()
+
+    # -- 内部 --
+
+    def _lock_for(self, thread_id: str) -> threading.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(thread_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[thread_id] = lock
+            return lock
+
+    def _discard(self, thread_id: str) -> None:
+        """丢弃失效缓存条目（不 kill，沙箱交给 TTL 回收）。"""
+        self._cache.pop(thread_id, None)
+
+
+# 进程级单例
+manager = SandboxManager()
+
+
+def _runtime_ids() -> tuple[str, str | None]:
+    """从 langgraph 运行时 config 取 (thread_id, user_id)。
+
+    deepagents 经 asyncio.to_thread 调用 backend 同步方法，contextvars 会
+    复制到工作线程，故同步方法内 get_config() 可取到会话上下文。
+    """
+    try:
+        from langgraph.config import get_config
+        cfg = get_config() or {}
+    except Exception as e:
+        raise RuntimeError(
+            f"沙箱后端只能在会话运行时调用（无法获取运行时上下文）：{e}")
+    conf = cfg.get("configurable") or {}
+    thread_id = conf.get("thread_id")
+    if not thread_id:
+        raise RuntimeError("沙箱后端只能在会话运行时调用：config 缺少 thread_id。")
+    return thread_id, conf.get("user_id")
+
+
+class RoutingSandboxBackend(SandboxBackendProtocol):
+    """按会话路由的 deepagents backend（编译期固定一个实例，运行时分发）。
+
+    每次方法调用解析当前会话的沙箱 backend 并委托；沙箱不存在时由
+    SandboxManager.acquire 惰性创建。方法集合与转发签名严格对齐
+    SandboxBackendProtocol（execute 必须带 timeout 关键字——deepagents
+    用 execute_accepts_timeout 内省；grep 带 max_count）。
+    """
+
+    def __init__(self, mgr: SandboxManager | None = None):
+        self._mgr = mgr or manager
+
+    def _backend(self):
+        thread_id, user_id = _runtime_ids()
+        return self._mgr.acquire(thread_id=thread_id, user_id=user_id)
+
+    @property
+    def id(self) -> str:
+        try:
+            return self._backend().id
+        except Exception:
+            return "routing-sandbox"
+
+    def execute(self, command: str, *, timeout: int | None = None):
+        return self._backend().execute(command, timeout=timeout)
+
+    def ls(self, path: str):
+        return self._backend().ls(path)
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000):
+        return self._backend().read(file_path, offset, limit)
+
+    def write(self, file_path: str, content: str):
+        return self._backend().write(file_path, content)
+
+    def edit(self, file_path: str, old_string: str, new_string: str,
+             replace_all: bool = False):
+        return self._backend().edit(file_path, old_string, new_string, replace_all)
+
+    def delete(self, file_path: str):
+        return self._backend().delete(file_path)
+
+    def grep(self, pattern: str, path: str | None = None, glob: str | None = None,
+             *, max_count: int | None = None):
+        return self._backend().grep(pattern, path, glob, max_count=max_count)
+
+    def glob(self, pattern: str, path: str | None = None):
+        return self._backend().glob(pattern, path)
+
+    def upload_files(self, files: list[tuple[str, bytes]]):
+        return self._backend().upload_files(files)
+
+    def download_files(self, paths: list[str]):
+        return self._backend().download_files(paths)

--- a/backend/app/spec.py
+++ b/backend/app/spec.py
@@ -15,7 +15,10 @@ class EmployeeSpec(BaseModel):
     tools: list[str] = []
     mcp_servers: dict = {}
     interrupt_on: dict = {}
-    backend: str = "state"  # 默认 StateBackend；分析师类员工用 "local_shell" 拿到 execute/read_file/ls/write_file
+    # state=StateBackend（无 shell）；local_shell=宿主机 LocalShellBackend；
+    # sandbox=OpenSandbox 沙箱（execute/fs 工具进沙箱容器，按会话路由；
+    #   SANDBOX_ENABLED 未置 1 时回退 local_shell，见 app/sandbox_mgr.py）
+    backend: str = "state"
     sop: str = ""  # SOP 说明：追加到 system_prompt，并用于"加载 SOP"阶段展示
     # ---- 目录库（catalog.db）驱动的新字段 ----
     kbs: list[str] = []          # 选中的知识库 id

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,6 @@ cryptography==45.0.5
 # 表格问答（上传 Excel/CSV → DuckDB 查询）
 duckdb==1.5.5
 openpyxl==3.1.5
+# OpenSandbox 沙箱执行环境（backend=sandbox 员工；SANDBOX_ENABLED=1 启用）
+opensandbox==0.1.16
+langchain-sandbox-opensandbox==0.1.2

--- a/tests/test_sandbox_mgr.py
+++ b/tests/test_sandbox_mgr.py
@@ -1,0 +1,324 @@
+"""OpenSandbox 沙箱管理与路由 backend 单测（fake SDK，不依赖真实 server）。
+
+覆盖：
+- 开关关闭时 acquire 报错、build_backends 回退 LocalShellBackend；
+- 开启后按会话创建/缓存/续租/重建沙箱，volumes 按用户 subPath 隔离；
+- 重启后凭 sandbox_sessions 表重连，重连失败转新建；
+- RoutingSandboxBackend 按 thread_id 路由并透传方法参数；
+- 沙箱不可用不回退宿主机（抛 RuntimeError）。
+"""
+import pytest
+
+from app import sandbox_mgr
+from app.sandbox_mgr import SandboxManager, RoutingSandboxBackend
+
+
+# ---- fakes ----
+
+class FakeSandbox:
+    """记录 renew/kill 调用的假 SDK 句柄。"""
+    def __init__(self, sid: str):
+        self.id = sid
+        self.renewed = 0
+        self.killed = 0
+
+    def renew(self, timeout):
+        self.renewed += 1
+
+    def kill(self):
+        self.killed += 1
+
+
+class FakeBackend:
+    """假 deepagents backend，记录所有转发调用。"""
+    def __init__(self, sandbox):
+        self._sandbox = sandbox
+        self.calls: list[tuple] = []
+
+    @property
+    def id(self):
+        return self._sandbox.id
+
+    def execute(self, command, *, timeout=None):
+        self.calls.append(("execute", command, timeout))
+        return ("exec-result", command, timeout)
+
+    def ls(self, path):
+        self.calls.append(("ls", path))
+        return ("ls", path)
+
+    def read(self, file_path, offset=0, limit=2000):
+        self.calls.append(("read", file_path, offset, limit))
+        return ("read", file_path)
+
+    def write(self, file_path, content):
+        self.calls.append(("write", file_path, content))
+        return ("write", file_path)
+
+    def edit(self, file_path, old_string, new_string, replace_all=False):
+        self.calls.append(("edit", file_path, replace_all))
+        return ("edit", file_path)
+
+    def delete(self, file_path):
+        self.calls.append(("delete", file_path))
+        return ("delete", file_path)
+
+    def grep(self, pattern, path=None, glob=None, *, max_count=None):
+        self.calls.append(("grep", pattern, path, glob, max_count))
+        return ("grep", pattern, max_count)
+
+    def glob(self, pattern, path=None):
+        self.calls.append(("glob", pattern, path))
+        return ("glob", pattern)
+
+    def upload_files(self, files):
+        self.calls.append(("upload", files))
+        return [("upload",) * len(files)]
+
+    def download_files(self, paths):
+        self.calls.append(("download", paths))
+        return [("download",) * len(paths)]
+
+
+def _patch_manager(monkeypatch, mgr, *, connect_fail=False):
+    """给 manager 装上 fake SDK 层，返回 (create_calls, connect_calls)。"""
+    create_calls: list[dict] = []
+    connect_calls: list[str] = []
+    counter = {"n": 0}
+
+    def fake_create(*, uid, thread_id):
+        counter["n"] += 1
+        create_calls.append({"uid": uid, "thread_id": thread_id})
+        return FakeSandbox(f"sb-{counter['n']}")
+
+    def fake_connect(sandbox_id):
+        connect_calls.append(sandbox_id)
+        if connect_fail:
+            raise RuntimeError("sandbox gone")
+        sb = FakeSandbox(sandbox_id)
+        sb.reconnected = True
+        return sb
+
+    def fake_wrap(sandbox):
+        return FakeBackend(sandbox)
+
+    monkeypatch.setattr(mgr, "_create", fake_create)
+    monkeypatch.setattr(mgr, "_connect", fake_connect)
+    monkeypatch.setattr(mgr, "_wrap", fake_wrap)
+    return create_calls, connect_calls
+
+
+@pytest.fixture
+def enabled_env(monkeypatch, tmp_path):
+    """开启沙箱开关并配好宿主机目录（tmp_path 验证路径透传）。"""
+    monkeypatch.setenv("SANDBOX_ENABLED", "1")
+    monkeypatch.setenv("SANDBOX_HOST_DATA", str(tmp_path / "data"))
+    monkeypatch.setenv("SANDBOX_HOST_DATASETS", str(tmp_path / "datasets"))
+    yield
+
+
+# ---- 开关与配置 ----
+
+def test_acquire_disabled_raises(monkeypatch):
+    monkeypatch.delenv("SANDBOX_ENABLED", raising=False)
+    mgr = SandboxManager()
+    with pytest.raises(RuntimeError, match="未启用"):
+        mgr.acquire(thread_id="t1", user_id="u1")
+
+
+def test_acquire_requires_thread_id(enabled_env):
+    mgr = SandboxManager()
+    with pytest.raises(RuntimeError, match="thread_id"):
+        mgr.acquire(thread_id="", user_id="u1")
+
+
+def test_enabled_flag(monkeypatch):
+    monkeypatch.delenv("SANDBOX_ENABLED", raising=False)
+    assert sandbox_mgr.enabled() is False
+    monkeypatch.setenv("SANDBOX_ENABLED", "1")
+    assert sandbox_mgr.enabled() is True
+
+
+# ---- 生命周期 ----
+
+def test_acquire_creates_and_caches_per_thread(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    create_calls, _ = _patch_manager(monkeypatch, mgr)
+
+    b1 = mgr.acquire(thread_id="t1", user_id="u1")
+    b2 = mgr.acquire(thread_id="t1", user_id="u1")
+    b3 = mgr.acquire(thread_id="t2", user_id="u2")
+
+    assert b1 is b2                       # 同会话复用
+    assert b1 is not b3                   # 不同会话独立沙箱
+    assert len(create_calls) == 2
+    assert create_calls[0] == {"uid": "u1", "thread_id": "t1"}
+    assert create_calls[1] == {"uid": "u2", "thread_id": "t2"}
+    # 第二次取用触发续租
+    assert b1._sandbox.renewed == 1
+    # 映射已落库
+    assert sandbox_mgr._load_session("t1") == "sb-1"
+    assert sandbox_mgr._load_session("t2") == "sb-2"
+
+
+def test_user_id_defaults(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    create_calls, _ = _patch_manager(monkeypatch, mgr)
+    mgr.acquire(thread_id="t1", user_id=None)
+    assert create_calls[0]["uid"] == "default"
+
+
+def test_renew_failure_recreates(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    create_calls, _ = _patch_manager(monkeypatch, mgr)
+
+    b1 = mgr.acquire(thread_id="t1", user_id="u1")
+    assert b1.id == "sb-1"
+
+    # 沙箱已死：renew 抛错 → 丢弃；重连健康检查也失败 → 新建
+    def dead_renew(timeout):
+        raise RuntimeError("sandbox expired")
+    b1._sandbox.renew = dead_renew
+
+    def dead_connect(sandbox_id):
+        raise RuntimeError("sandbox gone")
+    mgr._connect = dead_connect
+
+    b2 = mgr.acquire(thread_id="t1", user_id="u1")
+    assert b2.id == "sb-2"
+    assert len(create_calls) == 2
+    assert sandbox_mgr._load_session("t1") == "sb-2"
+
+
+def test_reconnect_after_restart(enabled_env, monkeypatch):
+    # 第一次：创建并落库
+    mgr1 = SandboxManager()
+    create_calls, _ = _patch_manager(monkeypatch, mgr1)
+    mgr1.acquire(thread_id="t1", user_id="u1")
+    assert create_calls == [{"uid": "u1", "thread_id": "t1"}]
+
+    # 模拟重启：新 manager 实例，缓存为空，凭库中 sandbox_id 重连
+    mgr2 = SandboxManager()
+    create_calls2, connect_calls2 = _patch_manager(monkeypatch, mgr2)
+    b = mgr2.acquire(thread_id="t1", user_id="u1")
+    assert connect_calls2 == ["sb-1"]      # 走重连
+    assert create_calls2 == []             # 未新建
+    assert b.id == "sb-1"
+
+
+def test_reconnect_failure_falls_back_to_create(enabled_env, monkeypatch):
+    mgr1 = SandboxManager()
+    _patch_manager(monkeypatch, mgr1)
+    mgr1.acquire(thread_id="t1", user_id="u1")
+
+    mgr2 = SandboxManager()
+    create_calls2, connect_calls2 = _patch_manager(monkeypatch, mgr2, connect_fail=True)
+    b = mgr2.acquire(thread_id="t1", user_id="u1")
+    assert connect_calls2 == ["sb-1"]
+    assert len(create_calls2) == 1         # 重连失败 → 新建
+    assert b.id == "sb-1" or b.id.startswith("sb-")
+    assert sandbox_mgr._load_session("t1") == b.id
+
+
+def test_kill_thread_clears_cache_and_db(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    _, _ = _patch_manager(monkeypatch, mgr)
+    b = mgr.acquire(thread_id="t1", user_id="u1")
+    assert sandbox_mgr._load_session("t1") == "sb-1"
+
+    mgr.kill_thread("t1")
+    assert b._sandbox.killed == 1
+    assert sandbox_mgr._load_session("t1") is None
+    # 再次 acquire 重新创建
+    create_calls, _ = _patch_manager(monkeypatch, mgr)
+    mgr.acquire(thread_id="t1", user_id="u1")
+    assert len(create_calls) == 1
+
+
+def test_create_requires_host_data(monkeypatch):
+    """未配置 SANDBOX_HOST_DATA 时真实 _create 路径报配置错误（不静默）。"""
+    monkeypatch.setenv("SANDBOX_ENABLED", "1")
+    monkeypatch.delenv("SANDBOX_HOST_DATA", raising=False)
+    mgr = SandboxManager()
+    with pytest.raises(RuntimeError, match="SANDBOX_HOST_DATA"):
+        mgr._create(uid="u1", thread_id="t1")
+
+
+# ---- RoutingSandboxBackend ----
+
+def test_routing_backend_dispatches_by_thread(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    _patch_manager(monkeypatch, mgr)
+    routing = RoutingSandboxBackend(mgr=mgr)
+
+    # 模拟 langgraph 运行时上下文
+    monkeypatch.setattr(sandbox_mgr, "_runtime_ids",
+                        lambda: ("t1", "u1"))
+    assert routing.execute("echo hi", timeout=42) == ("exec-result", "echo hi", 42)
+    assert routing.ls("/data") == ("ls", "/data")
+    assert routing.read("/f.txt", 10, 100) == ("read", "/f.txt")
+    assert routing.write("/f.txt", "x") == ("write", "/f.txt")
+    assert routing.edit("/f.txt", "a", "b", True) == ("edit", "/f.txt")
+    assert routing.delete("/f.txt") == ("delete", "/f.txt")
+    assert routing.grep("TODO", "/p", "*.py", max_count=5) == ("grep", "TODO", 5)
+    assert routing.glob("**/*.py") == ("glob", "**/*.py")
+    assert routing.upload_files([("/a", b"x")]) == [("upload",)]
+    assert routing.download_files(["/a"]) == [("download",)]
+
+    backend = mgr.acquire(thread_id="t1", user_id="u1")
+    assert ("execute", "echo hi", 42) in backend.calls
+    assert ("grep", "TODO", "/p", "*.py", 5) in backend.calls
+    # id 属性委托到沙箱
+    assert routing.id == "sb-1"
+
+
+def test_routing_backend_isolates_threads(enabled_env, monkeypatch):
+    mgr = SandboxManager()
+    _patch_manager(monkeypatch, mgr)
+    routing = RoutingSandboxBackend(mgr=mgr)
+
+    current = {"ids": ("t1", "u1")}
+    monkeypatch.setattr(sandbox_mgr, "_runtime_ids", lambda: current["ids"])
+
+    routing.execute("cmd-t1")
+    current["ids"] = ("t2", "u2")
+    routing.execute("cmd-t2")
+
+    b1 = mgr.acquire(thread_id="t1", user_id="u1")
+    b2 = mgr.acquire(thread_id="t2", user_id="u2")
+    assert ("execute", "cmd-t1", None) in b1.calls
+    assert ("execute", "cmd-t2", None) in b2.calls
+    assert ("execute", "cmd-t2", None) not in b1.calls
+
+
+def test_routing_backend_missing_runtime_raises(monkeypatch):
+    """非运行时上下文（取不到 thread_id）明确报错，不允许静默落宿主机。"""
+    monkeypatch.delenv("SANDBOX_ENABLED", raising=False)
+    routing = RoutingSandboxBackend(mgr=SandboxManager())
+
+    def _no_config():
+        raise RuntimeError("no config")
+    monkeypatch.setattr(sandbox_mgr, "_runtime_ids", _no_config)
+    with pytest.raises(RuntimeError):
+        routing.execute("echo hi")
+
+
+# ---- compiler 集成 ----
+
+def test_build_backends_sandbox_toggle(monkeypatch):
+    from app.compiler import build_backends
+    from app.spec import EmployeeSpec
+    from deepagents.backends import LocalShellBackend
+
+    spec = EmployeeSpec(id="net-ops", name="x", model="m", persona="p",
+                        backend="sandbox")
+
+    # 开关关闭 → 回退 LocalShellBackend（测试/开发零行为变化）
+    monkeypatch.delenv("SANDBOX_ENABLED", raising=False)
+    backend = build_backends(spec, None)
+    assert isinstance(backend.default, LocalShellBackend)
+
+    # 开关开启 → RoutingSandboxBackend
+    monkeypatch.setenv("SANDBOX_ENABLED", "1")
+    backend2 = build_backends(spec, None)
+    assert isinstance(backend2.default, RoutingSandboxBackend)


### PR DESCRIPTION
## 变更内容

接入本地部署的 OpenSandbox 作为沙箱执行环境，本 PR 为**基础设施层（PR 1/2，默认关闭、零行为变化）**。

- 新增 `backend/app/sandbox_mgr.py`：
  - `SandboxManager`：按会话（langgraph thread_id）管理沙箱生命周期。内存缓存 + catalog 新表 `sandbox_sessions` 持久化 thread→sandbox_id 映射（服务重启后可 `connect` 重连）；取用即 `renew` 续租 TTL；沙箱过期/失效自动重连或重建；**沙箱不可用时显式报错，不回退宿主机执行**。
  - `RoutingSandboxBackend`：实现 deepagents `SandboxBackendProtocol`。agent 按 (员工,用户) 编译缓存、backend 编译期固定，故由该代理在每次工具调用时按运行时 config 的 thread_id/user_id 路由到会话专属沙箱（execute/read_file/write_file 等全部落沙箱容器）。
  - 挂载：`/data` 按用户 `subPath=<uid>` 读写挂载（用户间隔离）、`/datasets` 共享数据集只读挂载。
- 接线：`compiler.build_backends` 新增 `backend="sandbox"` 分支（`SANDBOX_ENABLED=1` 生效，否则回退 `LocalShellBackend`）；catalog 启动幂等建表；`/health` 增加沙箱探活；requirements 固定 `opensandbox==0.1.16`、`langchain-sandbox-opensandbox==0.1.2`；`.env.example` 补 `SANDBOX_*` 配置；`spec.py` 注释补 sandbox 取值。

## 不在本 PR

- 沙箱镜像 Dockerfile、数据目录归一（uploads 迁移、workspace/datasets）、net-ops 切换为 sandbox 后端、run_python 改沙箱执行、真实环境验证 → PR 2（net-ops 试点）。
- 预热池 / egress FQDN 白名单 / api_key 强制 / 孤儿沙箱清扫 / 铺开其他员工 → 二期。

## 验证

- [x] 新增 14 个 fake-SDK 单测（创建/缓存/续租/重建/重连/按线程路由/开关回退/编译层接线）全绿
- [x] `pytest tests/ -q`：失败项与 main 基线逐项一致（test_isolation 基线 9 失败/分支 9 失败，test_security/test_assignment/test_summarization/浏览器测试均为既有问题）
- [x] 冒烟：开关关闭时 sandbox 员工回退 LocalShellBackend；开启时编译期构造 RoutingSandboxBackend 不触网；本地 OpenSandbox server (localhost:8090) /health 探活可达