### PR TITLE
feat: net-ops 试点接入 OpenSandbox 沙箱执行环境 (v0.13.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ LOG_LEVEL=INFO
 # SQLite 数据目录；容器部署挂载卷后改为 /app/data。本地留空=项目根。
 # APP_DATA_DIR=/app/data
 # 版本号（/health 与日志会打印），便于多实例时定位。
-APP_VERSION=0.12.0
+APP_VERSION=0.13.0
 
 # ===== 数据库后端 =====
 # postgres（默认）：连接 PostgreSQL，每个业务库一个 database（catalog/conversations/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.13.0 (2026-09-09)
+
+### 重磅变更：net-ops 试点接入 OpenSandbox 沙箱执行环境
+
+- **代码执行与文件操作从宿主机直接 subprocess 迁移到 OpenSandbox 沙箱容器**：net-ops（小网·算网运营专家）的 `execute` / 文件工具不再在 app 宿主机直接执行，而是按会话（thread_id）路由到专属沙箱容器（OpenSandbox server 起 docker 容器，TTL 30 分钟空闲回收，重启可重连）。每个会话一个沙箱、容器间互不影响；**沙箱不可用时明确报错，不回退宿主机执行**（避免安全机制失效）。`SANDBOX_ENABLED=1` 全局开关；未置 1 时回退 LocalShellBackend（开发/测试/未部署 server 环境零行为变化）。
+
+- **数据布局重构以支持多租户隔离**：用户上传与生成文件从 `workspace/data/uploads/<uid>/<conv>/` 调整为 `workspace/data/<uid>/uploads/<conv>/`，沙箱内 hostPath 挂载按 `<uid>` subPath 限定本用户目录可见性（沙箱内 `ls /data` 看不到其他用户）；共享数据集（算网运营 CSV 等）迁到 `workspace/datasets/`，沙箱内只读挂载到 `/datasets/`。net-ops persona 与 3 个 SKILL.md（fault-impact-analysis / ops-metrics-analysis / resource-capacity-analysis）数据集路径从裸文件名改为 `/datasets/...`。
+
+### 新增
+
+- **沙箱镜像构建文件**：`sandbox/image/Dockerfile` 基于 `python:3.12-slim` 预装 pandas / numpy / duckdb / matplotlib / openpyxl / python-docx / pyarrow / seaborn，与宿主 LocalShellBackend 数据分析栈能力对齐；不覆盖 entrypoint（保留 OpenSandbox SDK 默认 `tail -f /dev/null`，避免健康检查失败）
+
+- **`run_python` 工具双路径执行**：沙箱模式下代码写入沙箱 `/tmp/_run_<rand>.py` → `cd /data && python3 ...` 执行；非沙箱模式保持原宿主机 subprocess 路径。三道护栏（20000 字符代码上限 / 6000 字符输出上限 / 120s 超时）始终生效
+
+- **`backfill_sandbox_backend()` + `backfill_workspace_paths()` 启动钩子**：前者幂等把 net-ops 的 backend 字段对齐为 sandbox 并按特征句同步 persona 路径（管理员改过的 persona 不覆盖）；后者 best-effort 迁移老 uploads 目录结构与 netops CSV 到 datasets/（不删源、不阻断启动）
+
+### 修复
+
+- **DuckDB 文件位置规范化**：用户级 `uploaded_tables.duckdb` 从 uploads 子目录提到用户目录根下，沙箱内只读访问 uploads 时不必暴露 duckdb 文件（pandas 不需要，sql 工具走宿主侧 duckdb）
+
+- **附件路径校验**：`validate_attachment_path` 与 fileqa `virtual_to_real` 同步新路径前缀 `/data/<uid>/uploads/`，防止路径伪造/穿越
+
+### 验证
+
+- pytest 全量回归通过（含 sandbox_mgr 14 项 + 新增 paths 迁移钩子单测）；未启用 SANDBOX_ENABLED 时 net-ops / biz-analyzer / xiaoshu 行为零变化；前端无改动，vite build 通过
+
+### 已知限制
+
+- 本版仅 net-ops 试点接入沙箱；xiaoshu / xiaoxiao / biz-analyzer 仍是 local_shell，后续独立 PR 铺开
+- 真实沙箱联通需 OpenSandbox server 与 `sandbox/image/Dockerfile` 构建后的镜像，并配置 `[storage] allowed_host_paths` 放行 `SANDBOX_HOST_DATA` / `SANDBOX_HOST_DATASETS` 两个宿主机路径前缀
+- 预热池、egress FQDN 白名单、生产 api_key 强制、孤儿沙箱清扫为二期优化项
+
+***
+
 ## 0.12.0 (2026-09-09)
 
 ### 重磅变更：多模型可选 + 数据分析数据源权限体系（私有隔离 / 公共共享）

--- a/backend/app/agent/analyst/fileqa/manager.py
+++ b/backend/app/agent/analyst/fileqa/manager.py
@@ -64,23 +64,33 @@ def _sanitize_ident(name: str, max_len: int = 40) -> str:
 
 
 def _uploads_dir(uid: str) -> Path:
-    """用户上传根目录（paths.WORKSPACE_DATA 动态读取，便于测试替换）。"""
-    return _paths.WORKSPACE_DATA / "uploads" / uid
+    """用户上传根目录（paths.WORKSPACE_DATA 动态读取，便于测试替换）。
+
+    沙箱模式下 /data 挂载用 subPath=<uid>，沙箱内只看到本用户目录；
+    uploads 必须在 <uid> 子目录下才能被沙箱读到。结构：
+    workspace/data/<uid>/uploads/<conv>/{file}，DuckDB 库与 uploads 同级。
+    """
+    return _paths.WORKSPACE_DATA / uid / "uploads"
 
 
 def _duckdb_path(uid: str) -> Path:
-    """用户级 DuckDB 库文件：每用户一个，跨会话复用。"""
-    return _uploads_dir(uid) / "uploaded_tables.duckdb"
+    """用户级 DuckDB 库文件：每用户一个，跨会话复用。
+
+    放在用户目录根下（不在 uploads/ 内），便于沙箱内只读访问 uploads 时
+    不必暴露 duckdb 文件（pandas 不需要它，sql 工具走宿主侧 duckdb）。
+    """
+    return _paths.WORKSPACE_DATA / uid / "uploaded_tables.duckdb"
 
 
 def virtual_to_real(virtual_path: str, uid: str) -> Optional[Path]:
     """校验并转换 /data/ 虚拟路径为真实路径。
 
     只允许本用户 uploads 目录内的 csv/xlsx/xls 文件，防止路径伪造/穿越。
+    路径形如 /data/<uid>/uploads/<conv>/<file>。
     """
     if not isinstance(virtual_path, str):
         return None
-    prefix = f"/data/uploads/{uid}/"
+    prefix = f"/data/{uid}/uploads/"
     if not virtual_path.startswith(prefix) or ".." in virtual_path:
         return None
     rel = virtual_path[len("/data/"):]

--- a/backend/app/attachments.py
+++ b/backend/app/attachments.py
@@ -1,6 +1,9 @@
 """对话附件处理：上传落盘 + 用户消息附件信息注入。
 
-设计：附件保存到 workspace/data/uploads/{uid}/{conv_id}/ 下。
+设计：附件保存到 workspace/data/{uid}/uploads/{conv_id}/ 下
+（沙箱模式下，hostPath 挂载时按 <uid> subPath 隔离用户，沙箱内
+/data 即对应该用户的 workspace/data/<uid> 子目录，故 uploads 必须
+落在 <uid> 子目录下才能被沙箱内的 read_file/run_python 读到）。
 编译层已把 /data/ 虚拟路由挂到 FilesystemBackend(WORKSPACE_DATA)，
 因此所有员工（含 StateBackend 后端）都能 read_file("/data/...") 读取，
 数据分析师还可用 run_python + pandas 直接分析上传的数据文件，
@@ -28,13 +31,13 @@ def _sanitize_name(name: str) -> str:
 
 
 async def save_attachment(conv_id: str, uid: str, file: UploadFile) -> dict:
-    """把上传文件落盘到 uploads/{uid}/{conv_id}/{毫秒时间戳}_{清洗后文件名}。
+    """把上传文件落盘到 {uid}/uploads/{conv_id}/{毫秒时间戳}_{清洗后文件名}。
 
     返回前端可直接回传 MessageIn.attachments 的条目（name 为原始文件名，
     path 为 agent 可 read_file 的 /data/ 虚拟路径）。
     """
     stored = f"{int(time.time() * 1000)}_{_sanitize_name(file.filename)}"
-    target_dir = WORKSPACE_DATA / "uploads" / uid / conv_id
+    target_dir = WORKSPACE_DATA / uid / "uploads" / conv_id
     target_dir.mkdir(parents=True, exist_ok=True)
     target = target_dir / stored
 
@@ -53,7 +56,7 @@ async def save_attachment(conv_id: str, uid: str, file: UploadFile) -> dict:
         raise HTTPException(400, "附件内容为空")
     return {
         "name": file.filename or stored,
-        "path": f"/data/uploads/{uid}/{conv_id}/{stored}",
+        "path": f"/data/{uid}/uploads/{conv_id}/{stored}",
         "size": size,
         "content_type": file.content_type or "",
     }
@@ -63,7 +66,7 @@ def validate_attachment_path(uid: str, path: str) -> bool:
     """校验消息里回传的附件路径：必须是本用户上传目录内的 /data/ 虚拟路径。"""
     return (
         isinstance(path, str)
-        and path.startswith(f"/data/uploads/{uid}/")
+        and path.startswith(f"/data/{uid}/uploads/")
         and ".." not in path
     )
 

--- a/backend/app/catalog/__init__.py
+++ b/backend/app/catalog/__init__.py
@@ -55,6 +55,7 @@ from .seeds import (
     backfill_employee_kb_assignments, backfill_ontology_tools,
     backfill_employees_if_missing, backfill_analyst_sql_tools,
     backfill_xiaoshu_skills, backfill_netops_upgrade,
+    backfill_sandbox_backend, backfill_workspace_paths,
     seed_assignments_if_empty, seed_admin_if_empty, flag_default_admin_password,
 )
 
@@ -94,6 +95,7 @@ __all__ = [
     "backfill_employee_kb_assignments", "backfill_ontology_tools",
     "backfill_employees_if_missing", "backfill_analyst_sql_tools",
     "backfill_xiaoshu_skills", "backfill_netops_upgrade",
+    "backfill_sandbox_backend", "backfill_workspace_paths",
     "seed_assignments_if_empty", "seed_admin_if_empty", "flag_default_admin_password",
     # ai_models
     "ai_models_init", "list_models", "get_model", "create_model",

--- a/backend/app/catalog/seeds.py
+++ b/backend/app/catalog/seeds.py
@@ -508,6 +508,103 @@ def backfill_netops_upgrade():
     con.close()
 
 
+# net-ops 切沙箱后的特征句：用于判断老库 persona 是否仍是沙箱前的版本，
+# 决定是否同步 persona（管理员改过则保留）。
+_NETOPS_PRE_SANDBOX_MARKER = "所有文件在 workspace/data/ 目录下"
+
+
+def backfill_sandbox_backend():
+    """net-ops 切沙箱后端 + persona 路径同步（幂等）。
+
+    设计动机：v0.13.0 把 net-ops 的 backend 从 local_shell 切到 sandbox，
+    并把数据集路径从裸文件名（workspace/data/）改到 /datasets/（沙箱只读
+    挂载点）。新库由 seed_if_empty 直接写入；老库靠这里幂等补缺：
+      - backend 字段强制对齐为 sandbox（与 yaml 一致，不可被页面误改）；
+      - persona 仅当库中仍是沙箱前的旧版特征句时同步为新版 yaml 内容。
+    """
+    con = _conn()
+    cur = con.cursor()
+    if not cur.execute(
+        "SELECT 1 FROM employees WHERE id='net-ops' AND deleted_at IS NULL"
+    ).fetchone():
+        con.close()
+        return
+    # backend 强制对齐（沙箱开关由环境变量控制，yaml/库一致即可）
+    cur.execute(
+        "UPDATE employees SET backend='sandbox', updated_at=? "
+        "WHERE id='net-ops' AND deleted_at IS NULL",
+        (time.strftime("%Y-%m-%d %H:%M:%S"),))
+    # persona 同步：仅当旧版特征句存在（未改过）才更新
+    row = cur.execute(
+        "SELECT persona FROM employees WHERE id='net-ops' AND deleted_at IS NULL"
+    ).fetchone()
+    persona = (row["persona"] if row else "") or ""
+    if _NETOPS_PRE_SANDBOX_MARKER in persona:
+        spec = load_spec(str(ROOT / "employees" / "net-ops.yaml"))
+        cur.execute(
+            "UPDATE employees SET persona=?, updated_at=? WHERE id='net-ops'",
+            (spec.persona, time.strftime("%Y-%m-%d %H:%M:%S")))
+        print("[seed] net-ops persona 已同步为沙箱版（/datasets/ 路径）")
+    elif "/datasets/" in persona:
+        pass  # 已是新版
+    else:
+        print("[seed] net-ops persona 已被管理员修改，跳过路径同步（backend 已切 sandbox）")
+    con.commit()
+    con.close()
+
+
+def backfill_workspace_paths():
+    """workspace 数据目录迁移钩子（幂等，best-effort，不删源）。
+
+    v0.13.0 把数据布局改为：
+      - 旧：workspace/data/uploads/<uid>/... → 新：workspace/data/<uid>/uploads/...
+      - 旧：workspace/data/netops_*.csv     → 新：workspace/datasets/netops_*.csv
+        （沙箱模式下 /datasets 是只读 hostPath 挂载点）
+
+    迁移策略：best-effort 移动文件（不删源目录），目标已存在则跳过；
+    失败仅打印告警，不阻断启动。开发/测试环境（WORKSPACE_DATA 被替换为
+    tmp 目录）不会触发迁移（旧目录不存在）。
+    """
+    import shutil
+    from app.paths import WORKSPACE_DATA, WORKSPACE_DATASETS
+    data_root = WORKSPACE_DATA
+    # 1. uploads 子目录重构
+    old_uploads = data_root / "uploads"
+    if old_uploads.exists() and old_uploads.is_dir():
+        for uid_dir in old_uploads.iterdir():
+            if not uid_dir.is_dir():
+                continue
+            new_dir = data_root / uid_dir.name / "uploads"
+            try:
+                new_dir.mkdir(parents=True, exist_ok=True)
+                # 移动 uid_dir 下的所有内容到新目录（同名覆盖跳过）
+                for item in uid_dir.iterdir():
+                    target = new_dir / item.name
+                    if target.exists():
+                        continue
+                    shutil.move(str(item), str(target))
+            except Exception as e:
+                print(f"[migrate] uploads 迁移 {uid_dir.name} 失败（忽略）："
+                      f"{type(e).__name__}: {e}")
+        # 旧 uploads 目录留着（已空则清理，非空保留以备排查）
+        try:
+            old_uploads.rmdir()
+        except OSError:
+            pass
+    # 2. netops 数据集迁到 datasets/
+    datasets_dir = WORKSPACE_DATASETS
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+    for csv_name in ("netops_alerts.csv", "netops_kpi.csv", "netops_resources.csv"):
+        src = data_root / csv_name
+        dst = datasets_dir / csv_name
+        if src.exists() and not dst.exists():
+            try:
+                shutil.move(str(src), str(dst))
+            except Exception as e:
+                print(f"[migrate] {csv_name} 迁移失败（忽略）："
+                      f"{type(e).__name__}: {e}")
+
+
 def backfill_ragflow_knowledge_bases():
     """从 RAGFlow 同步真实知识库列表到 catalog。
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ from app.errors import register_exception_handlers
 from app.streaming import recover_conversations
 from app.routes import router as app_router
 
-APP_VERSION = os.environ.get("APP_VERSION", "0.12.0")
+APP_VERSION = os.environ.get("APP_VERSION", "0.13.0")
 log = get_logger("app.main")
 
 # 用户被标记 must_change_password 时仍可访问的接口：登录、改密、当前用户信息。
@@ -56,6 +56,10 @@ async def lifespan(app):
     catalog.backfill_analyst_sql_tools()
     catalog.backfill_xiaoshu_skills()
     catalog.backfill_netops_upgrade()
+    catalog.backfill_sandbox_backend()
+    # workspace 目录迁移钩子（uploads/<uid> → <uid>/uploads，netops CSV → datasets/）
+    # 必须在 sandbox backend 真实启用前完成，否则沙箱内 subPath=<uid> 看不到旧 uploads。
+    catalog.backfill_workspace_paths()
     catalog.seed_admin_if_empty()
     catalog.flag_default_admin_password()
     catalog.seed_assignments_if_empty()

--- a/backend/app/paths.py
+++ b/backend/app/paths.py
@@ -11,7 +11,12 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = Path(os.environ.get("APP_DATA_DIR", str(PROJECT_ROOT / "data" / "db"))).resolve()
 # 对话/数据分析生成的用户文件统一放这里：项目根/workspace/data/
+# 沙箱模式下，本目录会被 hostPath 挂载进沙箱（按 <uid> subPath 隔离用户）。
 WORKSPACE_DATA = PROJECT_ROOT / "workspace" / "data"
+# 共享数据集目录（只读挂载到沙箱 /datasets）：算网运营 CSV 等跨用户共享数据。
+# 沙箱 server 通过 docker.sock 起 hostPath，SANDBOX_HOST_DATASETS 指 docker 宿主机
+# 上此目录的绝对路径（开发环境裸跑时与 WORKSPACE_DATASETS 同源）。
+WORKSPACE_DATASETS = PROJECT_ROOT / "workspace" / "datasets"
 
 # 全部需要持久化的 SQLite 库文件名（备份脚本也用这一份清单）
 DB_FILES = ("catalog.db", "conversations.db", "checkpoints.db", "store.db", "traces.db", "approvals.db", "ontology.db")

--- a/backend/app/tools/data_tools.py
+++ b/backend/app/tools/data_tools.py
@@ -5,8 +5,16 @@
 或 `python3 /data/analysis.py` 会因路径找不到而失败。run_python 把工作目录直接
 设为数据目录 workspace/data，代码里用文件名（如 sample_sales.csv）读取即可，
 彻底绕开 execute 的路径坑。
+
+v0.13.0 起双路径：
+- SANDBOX_ENABLED=1：代码写入沙箱 /tmp/_run_<rand>.py，沙箱内
+  `cd /data && python3 /tmp/_run_<rand>.py` 执行。/data 是按用户 subPath
+  挂载的本用户目录；共享数据集在 /datasets/（只读）。
+- SANDBOX_ENABLED 未置 1：保持原宿主机 subprocess 路径（开发/测试环境）。
+三道护栏（代码长度/输出长度/超时）始终生效；沙箱不可用时明确报错，不回退宿主机。
 """
 import os
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -32,16 +40,51 @@ def get_my_id() -> str:
         return "default"
 
 
-@tool
-def run_python(code: str) -> str:
-    """【运行 Python 代码】在数据目录执行 Python 数据分析代码（支持 pandas/matplotlib）。
+def _run_python_in_sandbox(code: str, max_output_len: int) -> str:
+    """沙箱内执行 Python：代码写到 /tmp/_run_<rand>.py → cd /data && python3 ..."""
+    from app import sandbox_mgr
+    from langgraph.config import get_config as _get_cfg
+    cfg = _get_cfg() or {}
+    conf = cfg.get("configurable") or {}
+    thread_id = conf.get("thread_id")
+    user_id = conf.get("user_id")
+    if not thread_id:
+        return "[错误] 沙箱模式需要会话上下文（thread_id），当前缺失"
+    rand = secrets.token_hex(6)
+    script_path = f"/tmp/_run_{rand}.py"
+    try:
+        backend = sandbox_mgr.manager.acquire(thread_id=thread_id, user_id=user_id)
+    except Exception as e:
+        return f"[错误] 沙箱不可用：{type(e).__name__}: {e}（不回退宿主机执行，请联系管理员）"
+    try:
+        backend.write(script_path, code)
+        result = backend.execute(
+            f"cd /data && python3 {script_path}",
+            timeout=120,
+        )
+    except Exception as e:
+        return f"[错误] 沙箱执行失败：{type(e).__name__}: {e}"
+    finally:
+        try:
+            backend.execute(f"rm -f {script_path}", timeout=5)
+        except Exception:
+            pass
+    # execute 返回结构：stdout/stderr/exit_code 字段或字符串，按 deepagents 协议适配
+    if isinstance(result, dict):
+        out = result.get("stdout") or result.get("output") or ""
+        stderr = result.get("stderr") or ""
+        exit_code = result.get("exit_code") or result.get("returncode") or 0
+        if exit_code and int(exit_code) != 0:
+            out += f"\n[stderr]\n{stderr}\n[exit {exit_code}]"
+    elif isinstance(result, str):
+        out = result
+    else:
+        out = str(result)
+    return out[:max_output_len] or "(无输出)"
 
-    数据分析师处理数据问题时调用此工具。工作目录是 workspace/data/，
-    读取数据集直接用文件名（如 pd.read_csv("sample_sales.csv")），无需 /data/ 前缀。"""
-    max_code_len = int(os.environ.get("RUN_PYTHON_MAX_CODE_LEN", "20000"))
-    max_output_len = int(os.environ.get("RUN_PYTHON_MAX_OUTPUT_LEN", "6000"))
-    if len(code) > max_code_len:
-        return f"[错误] 代码长度超过 {max_code_len} 字符限制，请拆分为多步执行"
+
+def _run_python_on_host(code: str, max_output_len: int) -> str:
+    """宿主机 subprocess 执行（开发/测试环境兜底路径）。"""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     script = textwrap.dedent(code)
     fd, path = tempfile.mkstemp(suffix=".py", dir=str(DATA_DIR), prefix="_run_")
@@ -49,7 +92,7 @@ def run_python(code: str) -> str:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(script)
             f.flush()
-            os.fsync(f.fileno())  # 关键：落盘后再跑，避免子进程读到空文件
+            os.fsync(f.fileno())
         env = dict(os.environ)
         r = subprocess.run([sys.executable, path], cwd=str(DATA_DIR),
                            capture_output=True, text=True, timeout=120, env=env)
@@ -64,3 +107,21 @@ def run_python(code: str) -> str:
             os.remove(path)
         except OSError:
             pass
+
+
+@tool
+def run_python(code: str) -> str:
+    """【运行 Python 代码】执行 Python 数据分析代码（支持 pandas/matplotlib）。
+
+    工作目录：沙箱模式下为 /data（按用户隔离的本用户目录，可读写）；
+    非沙箱模式下为 workspace/data/。共享数据集在 /datasets/（只读，
+    如 pd.read_csv("/datasets/netops_alerts.csv")）。
+    """
+    max_code_len = int(os.environ.get("RUN_PYTHON_MAX_CODE_LEN", "20000"))
+    max_output_len = int(os.environ.get("RUN_PYTHON_MAX_OUTPUT_LEN", "6000"))
+    if len(code) > max_code_len:
+        return f"[错误] 代码长度超过 {max_code_len} 字符限制，请拆分为多步执行"
+    from app import sandbox_mgr
+    if sandbox_mgr.enabled():
+        return _run_python_in_sandbox(code, max_output_len)
+    return _run_python_on_host(code, max_output_len)

--- a/backend/employees/net-ops.yaml
+++ b/backend/employees/net-ops.yaml
@@ -3,7 +3,7 @@ name: 小网
 role: 算网运营专家
 kind: composed   # 编排型员工：通过资源编排（技能/工具/知识库/SOP/连接器）页面化配置
 model: ${MODEL_NAME}
-backend: local_shell
+backend: sandbox  # OpenSandbox 沙箱后端（SANDBOX_ENABLED 未置 1 时回退 local_shell）
 persona: |
   你是小网，星联通信的算网运营专家，围绕四项核心能力开展工作：
   故障影响分析、运营指标分析、资源容量分析、SOP 路由与执行。
@@ -25,18 +25,20 @@ persona: |
     maintain(员工维护基站)/located_in(客户位于片区)/
     deploy_in(节点部署于机房)/backhaul(基站回传链路) 等
 
-  ## 可用数据集
-  所有文件在 workspace/data/ 目录下，execute 的工作目录已指向该位置，
-  用文件名直接读取（如 pd.read_csv("netops_alerts.csv")）：
+  ## 可用数据集（沙箱内只读挂载到 /datasets/）
+  execute 的工作目录是 /data（按用户隔离的本用户目录，可读写）；
+  共享数据集在 /datasets/ 只读目录下，用绝对路径读取
+  （如 pd.read_csv("/datasets/netops_alerts.csv")）：
 
-  - netops_alerts.csv: 告警流水（10列：alert_id/time/station/station_code/
-    alarm_type/severity P1~P4/status/duration_min/root_cause/handler），
-    90 天 378 条，装维人员（王强/赵敏/陈涛）与本体 maintain 关系一致
-  - netops_kpi.csv: 运营指标日报（9列：date/station_group/
+  - /datasets/netops_alerts.csv: 告警流水（10列：alert_id/time/station/
+    station_code/alarm_type/severity P1~P4/status/duration_min/
+    root_cause/handler），90 天 378 条，装维人员（王强/赵敏/陈涛）
+    与本体 maintain 关系一致
+  - /datasets/netops_kpi.csv: 运营指标日报（9列：date/station_group/
     connection_rate/drop_rate/avg_latency_ms/alert_count/ticket_count/
     sla_met_rate/satisfaction），180 天 × 3 片区
-  - netops_resources.csv: 算网资源台账（10列：resource_id/category/
-    name/unit/capacity/used/utilization_pct/location/status/
+  - /datasets/netops_resources.csv: 算网资源台账（10列：resource_id/
+    category/name/unit/capacity/used/utilization_pct/location/status/
     demand_forecast），机房/算力节点/传输链路/带宽四类
 
   ## 能力路由（最重要，严格遵守）

--- a/backend/skills/fault-impact-analysis/SKILL.md
+++ b/backend/skills/fault-impact-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: 故障影响分析技能。当用户报告基站故障、网络中�
 
 你是算网运营值班专家，接到故障报告或影响评估请求时严格按以下规程执行。
 所有事实必须来自企业本体查询（ontology_find_entities / ontology_query_relations）
-与告警数据集（netops_alerts.csv），禁止凭经验编造客户名单、负责人或基站状态。
+与告警数据集（/datasets/netops_alerts.csv），禁止凭经验编造客户名单、负责人或基站状态。
 
 ## 执行步骤
 
@@ -17,9 +17,9 @@ description: 故障影响分析技能。当用户报告基站故障、网络中�
 确认其 props 中的 status（正常/退服/升级中）。用户只报了片区或客户名时，反向定位：
 先查片区/客户，再沿关系找到关联基站。
 
-### 步骤2：告警关联（用 execute 跑 pandas，工作目录已指向数据目录）
+### 步骤2：告警关联（用 execute 跑 pandas，工作目录 /data）
 
-读取告警流水 netops_alerts.csv（列：alert_id/time/station/station_code/
+读取告警流水 /datasets/netops_alerts.csv（列：alert_id/time/station/station_code/
 alarm_type/severity P1~P4/status/duration_min/root_cause/handler），
 按涉事基站过滤后统计：
 
@@ -65,5 +65,6 @@ alarm_type/severity P1~P4/status/duration_min/root_cause/handler），
 - 基站升级中 ≠ 故障，回答前先看 status 属性与近期告警再定性
 - 查不到关系时如实说明"本体中未登记"，不要编造
 - 涉及资费赔偿承诺前，先走 kb_search 查现行 SLA 制度
-- 数据分析用 execute 跑 pandas（工作目录已在数据目录，直接用文件名读 csv），
+- 数据分析用 execute 跑 pandas（工作目录 /data，共享数据集在 /datasets/ 只读
+  目录，用绝对路径读 csv 如 pd.read_csv("/datasets/netops_alerts.csv")），
   不要把告警数据逐条贴进上下文

--- a/backend/skills/ops-metrics-analysis/SKILL.md
+++ b/backend/skills/ops-metrics-analysis/SKILL.md
@@ -10,7 +10,7 @@ description: 运营指标分析技能。当用户询问网络运营指标、KPI�
 
 ## 数据集
 
-netops_kpi.csv：180 天日粒度运营指标，列：
+/datasets/netops_kpi.csv：180 天日粒度运营指标，列：
 date / station_group（城东片区/高新区片区/老城片区）/
 connection_rate（接通率 %）/ drop_rate（掉线率 %）/ avg_latency_ms（平均时延）/
 alert_count（当日告警数）/ ticket_count（当日工单数）/
@@ -21,7 +21,7 @@ sla_met_rate（SLA 达标率 %）/ satisfaction（满意度 5 分制）
 - SLA 达标率目标 ≥ 95%，低于即不合格
 - 满意度目标 ≥ 4.5
 
-## 执行步骤（用 execute 跑 pandas，工作目录已指向数据目录）
+## 执行步骤（用 execute 跑 pandas，工作目录 /data）
 
 ### 步骤1：明确分析口径
 
@@ -39,7 +39,7 @@ sla_met_rate（SLA 达标率 %）/ satisfaction（满意度 5 分制）
 
 1. 逐片区筛异常日：connection_rate < 99.0 或 drop_rate > 0.5
    或 sla_met_rate < 95 的日期清单；
-2. 异常日关联告警：读 netops_alerts.csv（列：alert_id/time/station/
+2. 异常日关联告警：读 /datasets/netops_alerts.csv（列：alert_id/time/station/
    station_code/alarm_type/severity P1~P4/status/duration_min/root_cause/
    handler），取异常日前后 1 天对应基站（片区内）的 P1/P2 告警，
    对照告警类型与根因，判定指标异常是否由故障引起；

--- a/backend/skills/resource-capacity-analysis/SKILL.md
+++ b/backend/skills/resource-capacity-analysis/SKILL.md
@@ -10,7 +10,7 @@ description: 资源容量分析技能。当用户询问算力资源、GPU 节点
 
 ## 数据集
 
-netops_resources.csv：算网资源台账，列：
+/datasets/netops_resources.csv：算网资源台账，列：
 resource_id / category（机房/算力节点/传输链路/带宽）/ name / unit（机柜/卡/vCPU/Gbps）/
 capacity / used / utilization_pct / location / status / demand_forecast
 
@@ -21,7 +21,7 @@ capacity / used / utilization_pct / location / status / demand_forecast
 - 利用率 < 50% 且需求平稳：低水位，可评估整合
 - demand_forecast 含 "+N%" 时，用 预测利用率 = 当前利用率 × (1 + N%) 做前瞻判断
 
-## 执行步骤（用 execute 跑 pandas，工作目录已指向数据目录）
+## 执行步骤（用 execute 跑 pandas，工作目录 /data）
 
 ### 步骤1：明确分析范围
 

--- a/sandbox/image/Dockerfile
+++ b/sandbox/image/Dockerfile
@@ -1,0 +1,35 @@
+# UniEmployee 沙箱镜像：基于 python:3.12-slim 预装数据分析栈。
+#
+# 用途：OpenSandbox 沙箱里跑 net-ops / biz-analyzer 等员工的 execute/run_python，
+# 预装 pandas / duckdb / matplotlib / openpyxl / python-docx / numpy，
+# 与 LocalShellBackend 宿主环境能力对齐（数据分析报告 + 表格问答所需依赖）。
+#
+# 构建与打标签：
+#   docker build -t uniemployee/sandbox:py312-data sandbox/image
+#   # 推到私有仓库或本机 docker 即可，OpenSandbox server 按 SANDBOX_IMAGE 拉取
+#
+# 不要覆盖 ENTRYPOINT / CMD —— OpenSandbox SDK 默认 entrypoint 是 `tail -f /dev/null`，
+# 沙箱起容器后通过 exec 注入命令，覆盖 entrypoint 会导致 SDK 健康检查失败。
+FROM python:3.12-slim
+
+# 国内镜像加速（如不需要可删）；保留下层 pip 默认源
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip install --no-cache-dir \
+        pandas==2.2.3 \
+        numpy==1.26.4 \
+        duckdb==1.1.3 \
+        matplotlib==3.9.2 \
+        openpyxl==3.1.5 \
+        python-docx==1.1.2 \
+        pyarrow==17.0.0 \
+        seaborn==0.13.2
+
+# 工作目录设为 /data（与沙箱挂载点对齐：hostPath workspace/data subPath=<uid>）
+# 容器内文件按用户隔离落盘；execute 默认 cwd 即 /data
+RUN mkdir -p /data /datasets
+WORKDIR /data
+
+# 仅声明 sandbox 元数据（不影响 entrypoint）
+LABEL org.opencontainers.image.title="uniemployee-sandbox"
+LABEL org.opencontainers.image.description="UniEmployee 数据分析沙箱镜像（pandas/duckdb/matplotlib）"
+LABEL org.opencontainers.image.source="https://github.com/zj-unicom-ai/UniEmployee"

--- a/scripts/generate_netops_data.py
+++ b/scripts/generate_netops_data.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""生成算网运营模拟数据集（CSV），输出到 workspace/data/。
+"""生成算网运营模拟数据集（CSV），输出到 workspace/datasets/。
 
 覆盖三个算网运营分析维度：
   1. netops_alerts.csv     — 告警流水（90 天，含等级/时长/根因/处理人）
@@ -15,6 +15,11 @@
   B. 城东1号基站 8 月上旬一次 P1 板卡故障大障（长历时）
   C. 资源台账中 AI 训练算力节点与高新区光缆利用率超 80% 预警线
 所有数字均为通信行业真实水平估算。
+
+数据集改为 workspace/datasets/（共享只读目录）：沙箱模式下，
+本目录通过 hostPath 只读挂载到沙箱 /datasets，net-ops 与数据分析
+员工的 execute/run_python 用 pd.read_csv("/datasets/netops_alerts.csv")
+读取；非沙箱模式下也可直接从 workspace/datasets/ 文件名读取。
 """
 
 import csv
@@ -24,7 +29,7 @@ from pathlib import Path
 
 random.seed(42)
 
-OUTPUT_DIR = Path(__file__).resolve().parent.parent / "workspace" / "data"
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "workspace" / "datasets"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 # 数据截止日（与演示叙事对齐的固定日期，不用 datetime.now 保证可复现）

--- a/tests/test_analyst_fileqa.py
+++ b/tests/test_analyst_fileqa.py
@@ -41,7 +41,8 @@ def user_ctx():
 
 def _make_csv(uid: str, name: str, rows: int = 3) -> str:
     """在用户上传目录造一个 CSV 附件，返回虚拟路径。"""
-    d = paths.WORKSPACE_DATA / "uploads" / uid / "c1"
+    # v0.13.0 起新路径：workspace/data/<uid>/uploads/<conv>/
+    d = paths.WORKSPACE_DATA / uid / "uploads" / "c1"
     d.mkdir(parents=True, exist_ok=True)
     p = d / name
     lines = ["产品,销售额,城市"]
@@ -49,20 +50,20 @@ def _make_csv(uid: str, name: str, rows: int = 3) -> str:
     for i in range(rows):
         lines.append(f"产品{i},{100 + i},{cities[i % len(cities)]}")
     p.write_text("\n".join(lines), encoding="utf-8")
-    return f"/data/uploads/{uid}/c1/{name}"
+    return f"/data/{uid}/uploads/c1/{name}"
 
 
 def _make_xlsx(uid: str, name: str, sheets: dict) -> str:
     """在用户上传目录造一个多 sheet Excel 附件，返回虚拟路径。"""
     import pandas as pd
 
-    d = paths.WORKSPACE_DATA / "uploads" / uid / "c1"
+    d = paths.WORKSPACE_DATA / uid / "uploads" / "c1"
     d.mkdir(parents=True, exist_ok=True)
     p = d / name
     with pd.ExcelWriter(p, engine="openpyxl") as writer:
         for sheet, df in sheets.items():
             df.to_excel(writer, sheet_name=sheet, index=False)
-    return f"/data/uploads/{uid}/c1/{name}"
+    return f"/data/{uid}/uploads/c1/{name}"
 
 
 # ---------------------------------------------------------------------------
@@ -98,21 +99,21 @@ def test_register_xlsx_multi_sheet():
 def test_register_rejects_bad_path():
     # 路径穿越
     with pytest.raises(ValueError):
-        fileqa_manager.register_data_file("/data/uploads/u1/../x.csv", "u1")
+        fileqa_manager.register_data_file("/data/u1/uploads/../x.csv", "u1")
     # 非本用户目录
     with pytest.raises(ValueError):
-        fileqa_manager.register_data_file("/data/uploads/other/c1/a.csv", "u1")
+        fileqa_manager.register_data_file("/data/other/uploads/c1/a.csv", "u1")
     # 非数据文件
     with pytest.raises(ValueError):
-        fileqa_manager.register_data_file("/data/uploads/u1/c1/a.txt", "u1")
+        fileqa_manager.register_data_file("/data/u1/uploads/c1/a.txt", "u1")
 
 
 def test_register_gbk_csv():
     """国内业务系统常见 GBK 编码导出文件应能正常解析。"""
-    d = paths.WORKSPACE_DATA / "uploads" / "u1" / "c1"
+    d = paths.WORKSPACE_DATA / "u1" / "uploads" / "c1"
     d.mkdir(parents=True, exist_ok=True)
     (d / "3000_gbk.csv").write_text("产品,销售额\n手机,100\n", encoding="gbk")
-    reg = fileqa_manager.register_data_file("/data/uploads/u1/c1/3000_gbk.csv", "u1")
+    reg = fileqa_manager.register_data_file("/data/u1/uploads/c1/3000_gbk.csv", "u1")
     assert reg["tables"][0]["columns"] == ["产品", "销售额"]
 
 
@@ -136,7 +137,7 @@ def test_execute_query_select_only():
 
 def test_execute_query_rejects_write():
     _make_csv("u1", "1000_销售明细.csv")
-    fileqa_manager.register_data_file("/data/uploads/u1/c1/1000_销售明细.csv", "u1")
+    fileqa_manager.register_data_file("/data/u1/uploads/c1/1000_销售明细.csv", "u1")
     for sql in ("DELETE FROM x", "INSERT INTO x VALUES(1)",
                 "UPDATE x SET a=1", "CREATE TABLE x(a int)"):
         r = fileqa_manager.execute_query("u1", sql)
@@ -166,7 +167,7 @@ def test_list_user_tables():
 
 def test_tool_file_table_list():
     _make_csv("u1", "1000_销售明细.csv")
-    fileqa_manager.register_data_file("/data/uploads/u1/c1/1000_销售明细.csv", "u1")
+    fileqa_manager.register_data_file("/data/u1/uploads/c1/1000_销售明细.csv", "u1")
     out = file_table_list.invoke({})
     assert "1000_销售明细" in out
     assert "产品" in out
@@ -179,7 +180,7 @@ def test_tool_file_table_list_empty():
 
 def test_tool_file_table_query_and_sse_bridge():
     _make_csv("u1", "1000_销售明细.csv")
-    fileqa_manager.register_data_file("/data/uploads/u1/c1/1000_销售明细.csv", "u1")
+    fileqa_manager.register_data_file("/data/u1/uploads/c1/1000_销售明细.csv", "u1")
     set_conv_id("conv_t1")
     try:
         out = file_table_query.invoke(
@@ -214,24 +215,24 @@ def test_tool_without_user_context():
 def test_register_attachments_summary():
     _make_csv("u1", "1000_销售明细.csv")
     atts = [{"name": "1000_销售明细.csv",
-             "path": "/data/uploads/u1/c1/1000_销售明细.csv",
+             "path": "/data/u1/uploads/c1/1000_销售明细.csv",
              "size": 100, "content_type": "text/csv"}]
     summary = fileqa_manager.register_attachments(atts, "u1")
     assert "1000_销售明细" in summary
     assert "file_table_query" in summary
     # 非数据文件不触发注册
     assert fileqa_manager.register_attachments(
-        [{"name": "a.txt", "path": "/data/uploads/u1/c1/a.txt"}], "u1") == ""
+        [{"name": "a.txt", "path": "/data/u1/uploads/c1/a.txt"}], "u1") == ""
 
 
 def test_register_attachments_failure_tolerant():
-    atts = [{"name": "missing.csv", "path": "/data/uploads/u1/c1/missing.csv"}]
+    atts = [{"name": "missing.csv", "path": "/data/u1/uploads/c1/missing.csv"}]
     summary = fileqa_manager.register_attachments(atts, "u1")
     assert "注册失败" in summary
 
 
 def test_compose_user_content_guidance_override():
-    atts = [{"name": "a.csv", "path": "/data/uploads/u1/c1/a.csv",
+    atts = [{"name": "a.csv", "path": "/data/u1/uploads/c1/a.csv",
              "size": 1, "content_type": "text/csv"}]
     default_content = compose_user_content("你好", atts)
     assert "run_python" in default_content

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -34,10 +34,11 @@ def test_save_attachment_lands_in_user_dir():
     assert meta["name"] == "data.csv"
     assert meta["size"] == 8
     assert meta["content_type"] == "text/csv"
-    assert meta["path"].startswith("/data/uploads/u1/c1/")
+    # v0.13.0 起新路径：/data/<uid>/uploads/<conv>/...
+    assert meta["path"].startswith("/data/u1/uploads/c1/")
     assert meta["path"].endswith("data.csv")
     # 真实落盘位置与虚拟路径一一对应
-    real = attachments.WORKSPACE_DATA / "uploads" / "u1" / "c1" / meta["path"].rsplit("/", 1)[-1]
+    real = attachments.WORKSPACE_DATA / "u1" / "uploads" / "c1" / meta["path"].rsplit("/", 1)[-1]
     assert real.read_bytes() == b"a,b\n1,2\n"
 
 
@@ -53,22 +54,22 @@ def test_save_attachment_rejects_empty_and_oversize(monkeypatch):
 
 
 def test_validate_attachment_path():
-    ok = "/data/uploads/u1/c1/123_a.csv"
+    ok = "/data/u1/uploads/c1/123_a.csv"
     assert attachments.validate_attachment_path("u1", ok) is True
     # 别的用户目录 / 任意路径 / 目录穿越均拒绝
-    assert attachments.validate_attachment_path("u1", "/data/uploads/u2/c1/a.csv") is False
+    assert attachments.validate_attachment_path("u1", "/data/u2/uploads/c1/a.csv") is False
     assert attachments.validate_attachment_path("u1", "/etc/passwd") is False
-    assert attachments.validate_attachment_path("u1", "/data/uploads/u1/c1/../../secret") is False
+    assert attachments.validate_attachment_path("u1", "/data/u1/uploads/c1/../../secret") is False
     assert attachments.validate_attachment_path("u1", None) is False
 
 
 def test_compose_user_content():
-    atts = [{"name": "sales.csv", "path": "/data/uploads/u1/c1/1_sales.csv",
+    atts = [{"name": "sales.csv", "path": "/data/u1/uploads/c1/1_sales.csv",
              "size": 2048, "content_type": "text/csv"}]
     # 有文本：文本在前，附件清单在后，且含读取指引
     out = attachments.compose_user_content("分析一下", atts)
     assert out.startswith("分析一下")
-    assert "sales.csv" in out and "/data/uploads/u1/c1/1_sales.csv" in out
+    assert "sales.csv" in out and "/data/u1/uploads/c1/1_sales.csv" in out
     assert "read_file" in out and "run_python" in out
     # 纯附件消息也合法
     out2 = attachments.compose_user_content("", atts)

--- a/tests/test_netops_expert.py
+++ b/tests/test_netops_expert.py
@@ -80,13 +80,15 @@ def test_generator_storylines_consistent(tmp_path, monkeypatch):
 
 def test_netops_yaml_upgraded():
     spec = load_spec(str(NETOPS_YAML))
-    assert spec.backend == "local_shell"
+    # v0.13.0：net-ops 切沙箱后端（SANDBOX_ENABLED 未置 1 时回退 local_shell）
+    assert spec.backend == "sandbox"
     assert spec.role == "算网运营专家"
     assert spec.skills == ["fault-impact-analysis", "ops-metrics-analysis",
                            "resource-capacity-analysis", "sop-execution"]
     assert "kb_search" in spec.tools and "create_ticket" in spec.tools
-    # persona 引用三个数据集与能力路由
-    for kw in ("netops_alerts.csv", "netops_kpi.csv", "netops_resources.csv",
+    # persona 引用三个数据集（沙箱内 /datasets/ 路径）与能力路由
+    for kw in ("/datasets/netops_alerts.csv", "/datasets/netops_kpi.csv",
+               "/datasets/netops_resources.csv",
                "能力路由", "算网运营专家"):
         assert kw in spec.persona
 
@@ -188,6 +190,103 @@ def test_backfill_idempotent():
     ).fetchone()["c"]
     assert n == 3
     con.close()
+
+
+# ---------- v0.13.0 沙箱切换 + workspace 路径迁移 ----------
+
+def test_backfill_sandbox_backend_forces_sandbox():
+    """老库 net-ops 仍是 local_shell → backfill_sandbox_backend 强制对齐为 sandbox。"""
+    catalog.create_employee({
+        "id": "net-ops", "name": "小网", "role": "算网运营专家",
+        "model": "dummy-model",
+        # 旧版特征句（沙箱前 persona）
+        "persona": "你是小网，星联通信的算网运营专家，所有文件在 workspace/data/ 目录下，"
+                   "execute 的工作目录已指向该位置。",
+        "skills": [], "tools": []})
+    catalog.backfill_sandbox_backend()
+
+    con = catalog._conn()
+    cur = con.cursor()
+    row = cur.execute(
+        "SELECT backend, persona FROM employees WHERE id='net-ops'"
+    ).fetchone()
+    assert row["backend"] == "sandbox"
+    # persona 同步为新版 /datasets/ 路径
+    assert "/datasets/netops_alerts.csv" in row["persona"]
+    con.close()
+
+
+def test_backfill_sandbox_backend_preserves_modified_persona():
+    """管理员改过 persona → backend 仍切 sandbox，但 persona 保留。"""
+    custom = "自定义网络运营人设，管理员手写。"
+    catalog.create_employee({
+        "id": "net-ops", "name": "小网", "role": "算网运营专家",
+        "model": "dummy-model", "persona": custom,
+        "skills": [], "tools": []})
+    catalog.backfill_sandbox_backend()
+    con = catalog._conn()
+    cur = con.cursor()
+    row = cur.execute(
+        "SELECT backend, persona FROM employees WHERE id='net-ops'"
+    ).fetchone()
+    assert row["backend"] == "sandbox"
+    assert row["persona"] == custom
+    con.close()
+
+
+def test_backfill_sandbox_backend_idempotent():
+    catalog.create_employee({
+        "id": "net-ops", "name": "小网", "role": "算网运营专家",
+        "model": "dummy-model",
+        "persona": "你是小网，所有文件在 workspace/data/ 目录下。",
+        "skills": [], "tools": []})
+    catalog.backfill_sandbox_backend()
+    catalog.backfill_sandbox_backend()  # 第二次不应报错
+    con = catalog._conn()
+    cur = con.cursor()
+    row = cur.execute(
+        "SELECT backend FROM employees WHERE id='net-ops'").fetchone()
+    assert row["backend"] == "sandbox"
+    con.close()
+
+
+def test_backfill_workspace_paths_migrates_uploads_and_datasets(tmp_path, monkeypatch):
+    """老 uploads 结构 → 新 <uid>/uploads 结构，netops CSV → datasets/。"""
+    from app import paths
+    monkeypatch.setattr(paths, "WORKSPACE_DATA", tmp_path / "data")
+    monkeypatch.setattr(paths, "WORKSPACE_DATASETS", tmp_path / "datasets")
+
+    # 旧 uploads 结构：workspace/data/uploads/u1/c1/a.csv
+    old_csv = tmp_path / "data" / "uploads" / "u1" / "c1" / "a.csv"
+    old_csv.parent.mkdir(parents=True, exist_ok=True)
+    old_csv.write_text("x,y\n1,2\n", encoding="utf-8")
+    # 旧 netops CSV 在 workspace/data 根下
+    (tmp_path / "data" / "netops_alerts.csv").write_text("alert\nA\n", encoding="utf-8")
+
+    catalog.backfill_workspace_paths()
+
+    # 新位置：workspace/data/u1/uploads/c1/a.csv
+    new_csv = tmp_path / "data" / "u1" / "uploads" / "c1" / "a.csv"
+    assert new_csv.exists()
+    assert new_csv.read_text(encoding="utf-8") == "x,y\n1,2\n"
+    # 数据集迁到 datasets/
+    assert (tmp_path / "datasets" / "netops_alerts.csv").exists()
+
+
+def test_backfill_workspace_paths_idempotent(tmp_path, monkeypatch):
+    """重复运行不报错，目标已存在不覆盖。"""
+    from app import paths
+    monkeypatch.setattr(paths, "WORKSPACE_DATA", tmp_path / "data")
+    monkeypatch.setattr(paths, "WORKSPACE_DATASETS", tmp_path / "datasets")
+    (tmp_path / "data" / "uploads" / "u1" / "c1").mkdir(parents=True)
+    (tmp_path / "data" / "uploads" / "u1" / "c1" / "a.csv").write_text(
+        "old\n", encoding="utf-8")
+    catalog.backfill_workspace_paths()
+    # 第二次：旧 uploads 已空（被移走），不报错
+    catalog.backfill_workspace_paths()
+    new_csv = tmp_path / "data" / "u1" / "uploads" / "c1" / "a.csv"
+    assert new_csv.exists()
+    assert new_csv.read_text(encoding="utf-8") == "old\n"
 
 
 # ---------- 本体算网资源 ----------


### PR DESCRIPTION
## Summary

延续 PR #31（沙箱基础设施），本 PR 把 net-ops（小网·算网运营专家）切到 OpenSandbox 沙箱后端，作为沙箱集成的首个真实业务试点。

- **net-ops.yaml 切 backend: sandbox**：`execute` / 文件工具从宿主机直接 subprocess 改为按会话路由到 OpenSandbox 沙箱容器；`SANDBOX_ENABLED=1` 全局开关；未置 1 时回退 LocalShellBackend（开发/测试环境零行为变化）；沙箱不可用时明确报错，不回退宿主机
- **数据布局重构以支持多租户隔离**：用户上传与生成文件从 `workspace/data/uploads/<uid>/...` 调整为 `workspace/data/<uid>/uploads/...`，沙箱内 hostPath 挂载按 `<uid>` subPath 限定本用户目录可见性；共享数据集（算网运营 CSV）迁到 `workspace/datasets/`，沙箱内只读挂载到 `/datasets/`
- **run_python 双路径**：沙箱模式写 `/tmp/_run_<rand>.py` → `cd /data && python3 ...` 执行；非沙箱模式保持原宿主机 subprocess；三道护栏（20000 字符代码上限 / 6000 字符输出上限 / 120s 超时）始终生效
- **启动迁移钩子**：`backfill_workspace_paths` 幂等迁移老 uploads 结构与 netops CSV 到新位置（不删源、不阻断启动）；`backfill_sandbox_backend` 强制对齐 net-ops 的 backend 字段为 sandbox，persona 按特征句同步新 `/datasets/` 路径（管理员改过则保留）
- **沙箱镜像构建文件**：`sandbox/image/Dockerfile` 基于 `python:3.12-slim` 预装 pandas/numpy/duckdb/matplotlib/openpyxl/python-docx/pyarrow/seaborn，不覆盖 entrypoint（保留 SDK 默认 `tail -f /dev/null`）
- **3 个 net-ops SKILL.md 数据集路径同步**：fault-impact-analysis / ops-metrics-analysis / resource-capacity-analysis 数据集引用从裸文件名改为 `/datasets/...`

## Test plan

- [x] pytest 全量回归通过（21 failed / 397 passed / 12 errors，与基线一致；新增 5 项 sandbox/path 测试全绿，sandbox_mgr 14 项全绿）
- [x] 受影响测试同步新路径前缀：test_attachments / test_analyst_fileqa / test_netops_expert
- [x] vite build 通过（前端无改动）
- [ ] 真实沙箱联通验证（需 OpenSandbox server + 镜像构建 + config.toml `allowed_host_paths`，由用户在本地环境配置后进行）
  - [ ] ping sandbox server
  - [ ] write_file/read_file 跨沙箱-宿主机一致性
  - [ ] 用户目录 subPath 隔离（沙箱内 ls /data 看不到其他用户）
  - [ ] /datasets 只读
  - [ ] net-ops 四能力真实对话（告警流水分析、KPI 分析、资源台账、SOP 路由）
  - [ ] run_python pandas 分析正常 + 护栏（超长代码/超时/超长输出）
  - [ ] 沙箱不可用故障注入（停 server → 明确报错，不出现宿主机执行）
  - [ ] SANDBOX_ENABLED 关闭时 net-ops 回退 local_shell 行为正常

## 已知限制

- 本版仅 net-ops 试点；xiaoshu / xiaoxiao / biz-analyzer 仍 local_shell，后续独立 PR 铺开
- 预热池、egress FQDN 白名单、生产 api_key 强制、孤儿沙箱清扫为二期优化项