### PR TITLE
feat(ui): 侧边栏栏目重排 + 系统设置菜单受控 + 平台首页视觉升级

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -26,6 +26,7 @@
           :collapsed-icon-size="22"
           :options="menuOptions"
           :value="activeKey"
+          v-model:expanded-keys="expandedKeys"
           @update:value="onMenuSelect"
         />
       </div>
@@ -96,7 +97,6 @@ function iconEl(svg) {
 const mainNavOptions = [
   { label: '平台首页', key: 'home', icon: iconEl('<path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '对话工作台', key: 'chat', icon: iconEl('<path d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
-  { label: 'IM 频道', key: 'im', icon: iconEl('<path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '会话历史', key: 'history', icon: iconEl('<path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
   { label: '资源中心', key: 'resources', icon: iconEl('<path d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>') },
 ]
@@ -120,6 +120,7 @@ const settingsNavOptions = [
     icon: iconEl('<path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'),
     children: [
       { label: '安全护栏', key: 'guard-words' },
+      { label: 'IM 频道', key: 'im' },
       { label: '模型管理', key: 'model-manager' },
       { label: '审计日志', key: 'audit-logs' },
     ],
@@ -153,11 +154,21 @@ const activeKey = computed(() => {
 })
 
 const menuOptions = computed(() => {
-  const items = [...mainNavOptions]
+  // 显式顺序：平台首页 → 对话工作台 → [员工管理] → 资源中心
+  //         → [业务本体/自动任务/用户管理/运行评估] → 会话历史 → [系统设置]
+  // 方括号项仅 admin 可见
+  const items = []
+  items.push(mainNavOptions.find(x => x.key === 'home'))
+  items.push(mainNavOptions.find(x => x.key === 'chat'))
   if (auth.isAdmin) {
-    // 管理类栏目插在资源中心后面（mainNavOptions 末尾位置）
-    items.splice(items.length, 0, ...adminOnlyNavOptions)
-    // 系统设置固定在最下方
+    items.push(adminOnlyNavOptions.find(x => x.key === 'admin')) // 员工管理放第三位
+  }
+  items.push(mainNavOptions.find(x => x.key === 'resources'))
+  if (auth.isAdmin) {
+    items.push(...adminOnlyNavOptions.filter(x => x.key !== 'admin'))
+  }
+  items.push(mainNavOptions.find(x => x.key === 'history')) // 会话历史放系统设置前
+  if (auth.isAdmin) {
     items.push(...settingsNavOptions)
   }
   return items
@@ -166,7 +177,13 @@ const menuOptions = computed(() => {
 function onMenuSelect(key) {
   if (key === 'landing') {
     router.push({ name: 'landing' })
-  } else if (key !== 'change-password') {
+    return
+  }
+  // 切到非系统设置范围内的栏目时，自动收起系统设置父项
+  if (!SETTINGS_GROUP_KEYS.includes(key)) {
+    expandedKeys.value = []
+  }
+  if (key !== 'change-password') {
     router.push({ name: key })
   } else {
     router.push({ name: 'change-password' })

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,25 +1,32 @@
 <!-- 平台首页：欢迎横幅、统计卡片、快捷入口、数字员工列表 -->
 <template>
   <div class="home-page">
-    <!-- 顶部欢迎横幅 -->
+    <!-- 顶部欢迎横幅：渐变主色 + 装饰光斑 -->
     <div class="hero-section">
+      <div class="hero-deco hero-deco-1"></div>
+      <div class="hero-deco hero-deco-2"></div>
       <div class="hero-content">
+        <div class="hero-badge">
+          <span class="hero-badge-dot"></span>
+          UniEmployee · 数字员工平台
+        </div>
         <h1 class="hero-title">
-          欢迎回来，<span class="gradient-text">{{ auth.username }}</span>
+          欢迎回来，<span class="hero-name">{{ auth.username }}</span>
         </h1>
-        <p class="hero-sub">UniEmployee 企业级数字员工平台 — 让 AI 成为你的数字劳动力</p>
-      </div>
-      <div class="hero-actions">
-        <n-button type="primary" @click="router.push({name:'chat'})" class="start-btn">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
-          开始对话
-        </n-button>
+        <p class="hero-sub">让 AI 成为你的数字劳动力 — 配置人设、技能、工具与知识库，开启企业级数字员工协作</p>
+        <div class="hero-actions">
+          <n-button type="primary" @click="router.push({name:'chat'})" class="start-btn">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+            开始对话
+          </n-button>
+        </div>
       </div>
     </div>
 
-    <!-- 统计卡片 -->
+    <!-- 统计卡片：左侧色条 + 大数字 -->
     <div class="stats-grid">
-      <div v-for="s in basicStats" :key="s.label" class="stat-card card card-hover">
+      <div v-for="s in basicStats" :key="s.label" class="stat-card card">
+        <div class="stat-bar" :style="{ background: s.accent }"></div>
         <div class="stat-icon" :style="{ background: s.color }">{{ s.icon }}</div>
         <div class="stat-body">
           <div class="stat-value">{{ s.value }}</div>
@@ -28,7 +35,7 @@
       </div>
     </div>
 
-    <!-- Token 统计 -->
+    <!-- Token 统计栏 -->
     <div class="token-bar" v-if="tokenStats.length">
       <div v-for="s in tokenStats" :key="s.label" class="token-item">
         <span class="token-label">{{ s.icon }} {{ s.label }}</span>
@@ -37,33 +44,38 @@
     </div>
 
     <!-- 快捷入口 -->
-    <div class="quick-grid">
-      <div class="quick-card card card-hover" @click="router.push({name:'chat'})">
-        <div class="quick-icon" style="background:linear-gradient(135deg,#3b82f6,#2563eb)">💬</div>
-        <div class="quick-info">
-          <div class="quick-label">对话工作台</div>
-          <div class="quick-desc">与你的数字员工交流</div>
-        </div>
+    <div class="section">
+      <div class="section-header">
+        <h2 class="section-title">快捷入口</h2>
       </div>
-      <div class="quick-card card card-hover" @click="router.push({name:'history'})">
-        <div class="quick-icon" style="background:linear-gradient(135deg,#8b5cf6,#6d28d9)">🕘</div>
-        <div class="quick-info">
-          <div class="quick-label">会话历史</div>
-          <div class="quick-desc">查看过往对话记录</div>
+      <div class="quick-grid">
+        <div class="quick-card card card-hover" @click="router.push({name:'chat'})">
+          <div class="quick-icon" style="background:linear-gradient(135deg,#3b82f6,#2563eb)">💬</div>
+          <div class="quick-info">
+            <div class="quick-label">对话工作台</div>
+            <div class="quick-desc">与你的数字员工交流</div>
+          </div>
         </div>
-      </div>
-      <div v-if="auth.isAdmin" class="quick-card card card-hover" @click="router.push({name:'admin'})">
-        <div class="quick-icon" style="background:linear-gradient(135deg,#10b981,#047857)">👥</div>
-        <div class="quick-info">
-          <div class="quick-label">员工管理</div>
-          <div class="quick-desc">配置数字员工</div>
+        <div class="quick-card card card-hover" @click="router.push({name:'history'})">
+          <div class="quick-icon" style="background:linear-gradient(135deg,#8b5cf6,#6d28d9)">🕘</div>
+          <div class="quick-info">
+            <div class="quick-label">会话历史</div>
+            <div class="quick-desc">查看过往对话记录</div>
+          </div>
         </div>
-      </div>
-      <div class="quick-card card card-hover" @click="router.push({name:'resources'})">
-        <div class="quick-icon" style="background:linear-gradient(135deg,#f59e0b,#b45309)">📚</div>
-        <div class="quick-info">
-          <div class="quick-label">资源中心</div>
-          <div class="quick-desc">管理技能与知识库</div>
+        <div v-if="auth.isAdmin" class="quick-card card card-hover" @click="router.push({name:'admin'})">
+          <div class="quick-icon" style="background:linear-gradient(135deg,#10b981,#047857)">👥</div>
+          <div class="quick-info">
+            <div class="quick-label">员工管理</div>
+            <div class="quick-desc">配置数字员工</div>
+          </div>
+        </div>
+        <div class="quick-card card card-hover" @click="router.push({name:'resources'})">
+          <div class="quick-icon" style="background:linear-gradient(135deg,#f59e0b,#b45309)">📚</div>
+          <div class="quick-info">
+            <div class="quick-label">资源中心</div>
+            <div class="quick-desc">管理技能与知识库</div>
+          </div>
         </div>
       </div>
     </div>
@@ -79,7 +91,7 @@
           v-for="emp in employees"
           :key="emp.id"
           class="emp-card card card-hover"
-          @click="startChat(emp.id)"
+          @click="startChat(emp)"
         >
           <div class="emp-avatar" :style="{ background: empGradient(emp.id) }">
             {{ emp.name?.charAt(0) || '?' }}
@@ -115,10 +127,10 @@ const employees = ref([])
 const loading = ref(true)
 
 const basicStats = reactive([
-  { icon: '👥', label: '数字员工', value: '—', color: 'rgba(59,130,246,0.10)' },
-  { icon: '⚡', label: '技能', value: '—', color: 'rgba(16,185,129,0.10)' },
-  { icon: '🔧', label: '工具', value: '—', color: 'rgba(139,92,246,0.10)' },
-  { icon: '💬', label: '会话', value: '—', color: 'rgba(245,158,11,0.10)' },
+  { icon: '👥', label: '数字员工', value: '—', color: 'rgba(59,130,246,0.12)', accent: 'linear-gradient(180deg,#3b82f6,#06b6d4)' },
+  { icon: '⚡', label: '技能', value: '—', color: 'rgba(16,185,129,0.12)', accent: 'linear-gradient(180deg,#10b981,#06b6d4)' },
+  { icon: '🔧', label: '工具', value: '—', color: 'rgba(139,92,246,0.12)', accent: 'linear-gradient(180deg,#8b5cf6,#ec4899)' },
+  { icon: '💬', label: '会话', value: '—', color: 'rgba(245,158,11,0.12)', accent: 'linear-gradient(180deg,#f59e0b,#ef4444)' },
 ])
 
 const tokenStats = reactive([
@@ -173,46 +185,117 @@ onMounted(loadData)
   padding: 32px 40px 64px;
 }
 
-/* 欢迎横幅 */
+/* 欢迎横幅：渐变主背景 + 装饰光斑 */
 .hero-section {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 36px;
-  gap: 24px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 45%, #06b6d4 100%);
+  border-radius: 18px;
+  padding: 36px 40px;
+  margin-bottom: 28px;
+  box-shadow: 0 12px 40px rgba(30,58,138,0.25);
+}
+.hero-deco {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(48px);
+  pointer-events: none;
+}
+.hero-deco-1 {
+  width: 280px; height: 280px;
+  top: -80px; right: -40px;
+  background: rgba(255,255,255,0.18);
+}
+.hero-deco-2 {
+  width: 220px; height: 220px;
+  bottom: -100px; left: 30%;
+  background: rgba(6,182,212,0.35);
+}
+.hero-content { position: relative; z-index: 1; }
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.12);
+  border-radius: 999px;
+  color: rgba(255,255,255,0.92);
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 14px;
+  backdrop-filter: blur(6px);
+}
+.hero-badge-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: #4ade80;
+  box-shadow: 0 0 8px #4ade80;
+  animation: pulse 2s ease-in-out infinite;
 }
 .hero-title {
-  font-size: 28px;
+  font-size: 30px;
   font-weight: 700;
-  color: #0f172a;
-  margin-bottom: 8px;
-  line-height: 1.25;
+  color: #fff;
+  margin-bottom: 10px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+.hero-name {
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 .hero-sub {
   font-size: 14px;
-  color: #64748b;
+  color: rgba(255,255,255,0.85);
   line-height: 1.6;
+  margin-bottom: 20px;
+  max-width: 580px;
 }
 .start-btn {
-  height: 40px;
+  height: 42px;
   padding: 0 24px !important;
   border-radius: 10px !important;
   font-weight: 600;
   font-size: 14px;
+  background: rgba(255,255,255,0.95) !important;
+  color: #1e3a8a !important;
+  border: none !important;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.15);
+}
+.start-btn:hover {
+  background: #fff !important;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
-/* 统计卡片 */
+/* 统计卡片：左侧色条 + 大数字 */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 14px;
-  margin-bottom: 24px;
+  margin-bottom: 18px;
 }
 .stat-card {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 18px;
+  padding: 18px 18px 18px 22px;
+  overflow: hidden;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(15,23,42,0.08);
+}
+.stat-bar {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  border-radius: 0 4px 4px 0;
 }
 .stat-icon {
   width: 46px;
@@ -224,16 +307,18 @@ onMounted(loadData)
   font-size: 20px;
   flex-shrink: 0;
 }
+.stat-body { flex: 1; min-width: 0; }
 .stat-value {
   font-size: 26px;
   font-weight: 700;
   color: #0f172a;
   line-height: 1;
+  letter-spacing: -0.01em;
 }
 .stat-label {
   font-size: 13px;
   color: #64748b;
-  margin-top: 3px;
+  margin-top: 4px;
 }
 
 /* Token 统计栏 */
@@ -251,16 +336,46 @@ onMounted(loadData)
   background: #fff;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.token-item:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 4px 14px rgba(15,23,42,0.05);
 }
 .token-label { font-size: 13px; color: #64748b; }
 .token-value { font-size: 18px; font-weight: 700; color: #0f172a; }
+
+/* 分节 */
+.section { margin-bottom: 32px; }
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+.section-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: #0f172a;
+  position: relative;
+  padding-left: 12px;
+}
+.section-title::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 16px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #3b82f6, #06b6d4);
+}
+.section-more { font-size: 13px; }
 
 /* 快捷入口 */
 .quick-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
-  margin-bottom: 40px;
 }
 .quick-card {
   display: flex;
@@ -268,6 +383,11 @@ onMounted(loadData)
   gap: 14px;
   padding: 16px;
   cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.quick-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 28px rgba(15,23,42,0.08);
 }
 .quick-icon {
   width: 44px;
@@ -278,6 +398,7 @@ onMounted(loadData)
   justify-content: center;
   font-size: 20px;
   flex-shrink: 0;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.10);
 }
 .quick-label {
   font-size: 14px;
@@ -288,22 +409,6 @@ onMounted(loadData)
   font-size: 12px;
   color: #64748b;
   margin-top: 2px;
-}
-
-/* 分节标题 */
-.section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-.section-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: #0f172a;
-}
-.section-more {
-  font-size: 13px;
 }
 
 /* 员工网格 */
@@ -318,6 +423,12 @@ onMounted(loadData)
   gap: 16px;
   padding: 18px 20px;
   cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.emp-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px rgba(15,23,42,0.10);
+  border-color: #cbd5e1;
 }
 .emp-avatar {
   width: 52px;
@@ -330,6 +441,7 @@ onMounted(loadData)
   font-weight: 700;
   color: #fff;
   flex-shrink: 0;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.12);
 }
 .emp-name {
   font-size: 15px;
@@ -348,5 +460,35 @@ onMounted(loadData)
   display: flex;
   align-items: center;
   gap: 6px;
+}
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 0 rgba(16,185,129,0.5);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+@keyframes pulse-dot {
+  0% { box-shadow: 0 0 0 0 rgba(16,185,129,0.5); }
+  70% { box-shadow: 0 0 0 6px rgba(16,185,129,0); }
+  100% { box-shadow: 0 0 0 0 rgba(16,185,129,0); }
+}
+
+/* 空态 */
+.empty-hint {
+  grid-column: 1 / -1;
+  padding: 40px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 14px;
+  background: #fff;
+  border: 1px dashed #e2e8f0;
+  border-radius: 12px;
 }
 </style>


### PR DESCRIPTION
## 变更内容

### 侧边栏与导航交互
- **IM 频道归类**：从主导航移入「系统设置」子菜单（admin 可见，位于安全护栏后）
- **栏目顺序调整**：员工管理上移至第三位；会话历史下移至系统设置前
- **菜单受控展开**：n-menu 改为 `v-model:expanded-keys` 受控模式，切到非系统设置栏目时自动收起父项（修复"系统设置展开后不收起"问题）

### 平台首页视觉升级
- hero 区改蓝青渐变背景 + 装饰光斑 + 顶部 badge + 用户名金色渐变
- 统计卡片加左侧色条 + hover 上浮
- 快捷入口独立成 section + 卡片 hover 投影
- 数字员工卡片 hover 上浮 + 状态点脉冲动画
- startChat 区分 kind=custom 跳 analyst 工作台（修复 xiaoshu 点击跳老 chat 路由）

## 验证
- [x] `cd frontend && npx vite build` 通过