### PR TITLE
fix(security): 数据分析 SQL 只读校验 AST 化 + 表预览注入防御 (v0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.13.1 (2026-09-09)
+
+### 修复：数据分析 SQL 只读校验从字符串级升级为 AST 级
+
+- **历史漏洞**：`analyst/datasource/manager.py::execute_query` 用 `startswith` 关键词判断 SQL 是否只读，存在多条绕过路径——`/* comment */ DROP TABLE x` 注释前缀绕过、`SELECT ... ; DROP TABLE x` 多语句（stacked queries）、`WITH x AS (DELETE ...) SELECT` CTE 改写 DML、`SELECT ... INTO new_tbl` 建表、`SELECT pg_terminate_backend(pid)` 危险函数调用，均能逃逸只读约束。`analyst.py::preview_table_data` 用 `f"SELECT * FROM {table_name}"` 直接拼字符串，`table_name` 来自 URL 路径参数，等价 SQL 注入通道（`customers; DROP TABLE orders`、`information_schema.tables` 均可注入）。
+
+- **修复策略（纵深防御三道闸）**：
+  1. AST 校验：引入 `sqlglot==26.29.0` 按数据源方言解析 SQL，多语句拒绝、根节点必须是 SELECT、CTE 体只允许 SELECT、SELECT INTO 拒绝、危险函数黑名单（pg_terminate_backend / pg_sleep / load_file / sleep / benchmark / sys_exec / xp_cmdshell 等）。解析失败 fail-closed。
+  2. 行数硬上限：服务端 `fetchmany(min(limit, _QUERY_MAX_ROWS))` 取代 `fetchall`，杜绝全表载入内存；用户 limit 与全局 `ANALYST_QUERY_MAX_ROWS`（默认 1000）取较小者，SQL 字符串追加 LIMIT 仅作 DB 端兜底。
+  3. 服务端超时：PG `SET LOCAL statement_timeout` / MySQL `SET SESSION MAX_EXECUTION_TIME`，可通过 `ANALYST_QUERY_TIMEOUT_SEC`（默认 30s）环境变量覆盖；其他方言退化到 SQLAlchemy `execution_options(timeout=)` 客户端 cancel；失败不阻断（仅日志）。
+
+- **表预览路由注入修复**：新增 `is_table_readable(ds_id, table_name)` 严格白名单（先字符级防注入字符，再 inspector.get_table_names / get_view_names 校验真实存在），不存在即 404；新增 `quote_table_identifier` 用方言 `identifier_preparer.quote_identifier` 引用标识符拼 SQL。两道闸配合等价参数化但支持 identifier 绑定（SQLAlchemy 的 `text(":tbl")` 不支持 identifier 绑定）。
+
+### 验证
+
+- 新增 40 个单元测试覆盖关键绕过路径：多语句拒绝、CTE 改写 DML 拒绝、SELECT INTO 拒绝、危险函数拒绝（pg_terminate_backend / sleep / load_file / benchmark）、注释前缀 DROP 拒绝、SQL 语法错误 fail-closed、fetchmany 全局行数硬上限、is_table_readable 拒 8 类注入字符串（`; DROP` / `WHERE 1=1` / `--` / `/* */` / information_schema / `' OR '1'='1` / UNION 等）
+- analyst 全套 193 个测试通过；其他模块未回归（isolation/security/assignment/browser 失败在 main 上同存，与本次无关）
+- 前端构建通过
+
 ## 0.13.0 (2026-09-09)
 
 ### 重磅变更：net-ops 试点接入 OpenSandbox 沙箱执行环境 + 平台首页视觉与导航重构

--- a/backend/app/agent/analyst/datasource/manager.py
+++ b/backend/app/agent/analyst/datasource/manager.py
@@ -14,6 +14,8 @@ import time
 import urllib.parse
 from typing import Any
 
+import sqlglot
+from sqlglot import exp
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine
 
@@ -21,6 +23,147 @@ from app import db as dblayer
 from app.catalog.db import _conn as _catalog_conn
 
 logger = logging.getLogger("app.agent.analyst.datasource")
+
+# ---------------------------------------------------------------------------
+# SQL 只读安全护栏（AST 级）
+# ---------------------------------------------------------------------------
+# 历史问题：startswith 关键词判断可被注释/括号/CTE 改写 DML/方言函数绕过；
+# table_preview 直接 f-string 拼接 table_name 等价 SQL 注入通道。
+# 修复策略：sqlglot AST 解析 + 多语句拒绝 + CTE 体只允许 SELECT + 危险函数黑名单。
+
+# sqlglot 方言映射（datasource.db_type -> sqlglot dialect）
+_SQLGLOT_DIALECTS = {
+    "mysql": "mysql",
+    "pg": "postgres",
+    "postgres": "postgres",
+    "oracle": "oracle",
+    "sqlServer": "tsql",
+    "mssql": "tsql",
+    "ck": "clickhouse",
+    "clickhouse": "clickhouse",
+    "sqlite": "sqlite",
+}
+
+# 危险函数：可用于数据破坏/资源耗尽/文件系统/进程管理/信息泄露。
+# 大小写不敏感匹配（已 lower 处理）。pg_read_* / pg_sleep / pg_terminate_backend 等数据库特有
+# 系统管理函数，及 MySQL INTO OUTFILE / INTO DUMPFILE 类（sqlglot 解析为 Select.into，
+# 已在 stmt.args["into"] 处单独拦截，这里再防御同名函数调用）。
+_DANGEROUS_FUNCTIONS = {
+    "pg_terminate_backend", "pg_cancel_backend", "pg_sleep", "pg_sleep_for",
+    "pg_sleep_until", "pg_read_file", "pg_read_binary_file", "pg_ls_dir",
+    "pg_stat_file", "pg_ls_dir", "pg_size_pretty", "pg_database_size",
+    "pg_tablespace_size", "lo_import", "lo_export", "lo_unlink",
+    "load_file", "benchmark", "sleep", "get_lock", "release_all_locks",
+    "sys_exec", "sys_eval", "xp_cmdshell",
+}
+
+# 查询资源限制（可在启动时通过环境变量覆盖）
+_QUERY_TIMEOUT_SEC = float(os.environ.get("ANALYST_QUERY_TIMEOUT_SEC", "30"))
+_QUERY_MAX_ROWS = int(os.environ.get("ANALYST_QUERY_MAX_ROWS", "1000"))
+
+
+def _sqlglot_dialect_for(db_type: str) -> str:
+    """根据 datasource.db_type 返回 sqlglot 方言名。未知类型用默认（不指定）。"""
+    if not db_type:
+        return ""
+    return _SQLGLOT_DIALECTS.get(db_type, "")
+
+
+def _validate_readonly_sql(sql: str, db_type: str = "") -> tuple[bool, str]:
+    """AST 级只读校验，返回 (is_safe, error_message)。
+
+    通过条件：
+    1. sqlglot 解析后只能得到 1 条语句（拒绝多语句 stacked queries）。
+    2. 根节点必须是 SELECT（含 WITH ... SELECT 的 CTE 形式；CTE body 也只能是 SELECT）。
+    3. SELECT 语句不得带 INTO（PG 建表）。
+    4. 不得调用 _DANGEROUS_FUNCTIONS 中的函数。
+    5. 不允许 PIVOT/UNPIVOTE 等改写 schema 的扩展形式。
+
+    解析失败（语法错误/方言不识别）会被拒绝而非放行——安全场景下 fail-closed。
+    """
+    if not sql or not sql.strip():
+        return False, "SQL 为空"
+
+    dialect = _sqlglot_dialect_for(db_type)
+    try:
+        statements = sqlglot.parse(sql, dialect=dialect or None)
+    except Exception as e:
+        # 解析失败一律拒绝，避免脏 SQL 借解析器 bug 通过
+        logger.warning("SQL AST 解析失败 [db_type=%s]: %s", db_type, e)
+        return False, f"SQL 语法解析失败，已拒绝执行：{type(e).__name__}"
+
+    if not statements:
+        return False, "SQL 解析为空"
+
+    # 1. 多语句拒绝（sqlglot 对多语句分隔的 SQL 返回 list[Expression]）
+    non_none = [s for s in statements if s is not None]
+    if len(non_none) != 1:
+        return False, "禁止多语句执行（stacked queries rejected）"
+
+    stmt = non_none[0]
+
+    # 2. 根节点必须是 SELECT（含 WITH/CTE 的 SELECT 仍是 exp.Select）
+    if not isinstance(stmt, exp.Select):
+        # 显式拒绝常见 DML/DDL 节点，错误信息更具操作性（关键词大写便于识别）
+        kind_name = type(stmt).__name__.upper()
+        return False, f"安全限制：禁止执行 {kind_name} 语句，只允许 SELECT"
+
+    # 3. SELECT INTO 拒绝（PostgreSQL `SELECT ... INTO` 会建表）
+    if stmt.args.get("into"):
+        return False, "安全限制：禁止 SELECT INTO（避免建表）"
+
+    # 4. CTE body 必须是 SELECT（防 `WITH x AS (DELETE ...) SELECT`）
+    for cte in stmt.find_all(exp.CTE):
+        body = cte.this
+        # sqlglot 把 CTE 体包在 Subquery 里
+        if isinstance(body, exp.Subquery):
+            body = body.this
+        if body is not None and not isinstance(body, exp.Select):
+            return False, "安全限制：CTE 体内只允许 SELECT"
+
+    # 5. 危险函数黑名单（跨方言）
+    for func in stmt.find_all(exp.Anonymous):
+        fname = (func.name or "").lower().strip()
+        if fname in _DANGEROUS_FUNCTIONS:
+            return False, f"安全限制：禁止调用函数 {fname}"
+
+    # 6. 防御：SELECT 中不应出现 DDL/DML 子查询（如 `SELECT * FROM (DELETE ...) x`）
+    for bad_kind in (exp.Insert, exp.Update, exp.Delete, exp.Drop,
+                     exp.Create, exp.Alter, exp.Merge, exp.TruncateTable,
+                     exp.Command):
+        # 根节点已在 2 中处理；这里只查子节点
+        found = stmt.find(bad_kind)
+        if found is not None:
+            return False, f"安全限制：SELECT 中嵌套了 {bad_kind.__name__} 子语句"
+
+    return True, ""
+
+
+def _apply_session_safety_limits(conn, db_type: str, timeout_sec: float) -> None:
+    """在当前连接/事务上设置服务端语句超时。
+
+    PG: SET LOCAL statement_timeout = '<sec>s'（事务级，连接关闭自动恢复）。
+    MySQL: SET SESSION MAX_EXECUTION_TIME = <ms>（会话级；下一次 connect 复用 engine
+        时仍是同一 pool 连接，但 SET 是 session 级不会持久污染其他会话——连接池
+        实现层会在归还时执行 rollback 清理事务状态）。
+    SQL Server / Oracle / ClickHouse：暂不强制，依赖 _QUERY_TIMEOUT_SEC 通过
+        SQLAlchemy execution_options(timeout=) 兜底（client 端 cancel）。
+    SQLite：不支持 statement_timeout，跳过（测试用，不影响生产）。
+
+    失败不抛错：部分驱动对未知 SET 命令会报错，这里 log 后吞掉，
+    避免护栏机制反而阻断正常查询。
+    """
+    if timeout_sec <= 0:
+        return
+    try:
+        if db_type in ("pg", "postgres"):
+            conn.execute(text(f"SET LOCAL statement_timeout = '{int(timeout_sec)}s'"))
+        elif db_type == "mysql":
+            # MAX_EXECUTION_TIME 单位为毫秒
+            conn.execute(text(f"SET SESSION MAX_EXECUTION_TIME = {int(timeout_sec * 1000)}"))
+    except Exception as e:
+        # 仅日志，不阻断——sqlglot 已挡住危险语句，超时是纵深防御
+        logger.debug("设置服务端超时失败 [db_type=%s]: %s", db_type, e)
 
 # ---------------------------------------------------------------------------
 # 加密 / 解密（轻量 AES-GCM，密钥取环境变量）
@@ -377,39 +520,96 @@ def delete_datasource(datasource_id: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def execute_query(datasource_id: str, sql: str, limit: int = 100) -> dict:
-    """执行 SELECT 查询，返回 {success, data, columns, error}。
+    """执行 SELECT 查询，返回 {success, data, columns, error, row_count}。
 
-    安全：只允许 SELECT，禁止 INSERT/UPDATE/DELETE 等。
+    安全（纵深防御三道闸）：
+    1. AST 校验：sqlglot 解析 + 多语句拒绝 + CTE 体只允许 SELECT + 危险函数黑名单。
+       历史的 startswith 关键词判断可被注释/括号/CTE 改写 DML 绕过，已废弃。
+    2. 行数硬上限：服务端 fetchmany(min(limit, _QUERY_MAX_ROWS))，杜绝 fetchall
+       把全表拉进内存；即使 SQL 自带 LIMIT 也走 fetchmany 兜底。
+    3. 超时：PG SET LOCAL statement_timeout / MySQL MAX_EXECUTION_TIME，
+       失败不阻断（仅日志）；SQLite 等不支持则跳过。
     """
-    sql_stripped = sql.strip().upper()
-    forbidden = ("INSERT", "UPDATE", "DELETE", "DROP", "ALTER",
-                 "TRUNCATE", "CREATE", "GRANT", "REVOKE")
-    # 检查是否以禁止语句开头（跳过前导空白和 WITH/括号）
-    check_sql = sql.strip()
-    # CTE 以 WITH 开头是允许的
-    if check_sql.upper().startswith("WITH"):
-        pass
-    elif not check_sql.upper().startswith("SELECT"):
-        for kw in forbidden:
-            if check_sql.upper().startswith(kw):
-                return {"success": False, "data": None, "columns": None,
-                        "error": f"安全限制：禁止执行 {kw} 语句，只允许 SELECT"}
+    if not sql or not sql.strip():
+        return {"success": False, "data": None, "columns": None,
+                "error": "SQL 为空", "row_count": 0}
 
-    # 加 LIMIT（如果用户没加）
-    if "LIMIT" not in sql_stripped:
-        sql = sql.rstrip(";").rstrip() + f" LIMIT {limit}"
+    ds = get_datasource(datasource_id)
+    if not ds:
+        return {"success": False, "data": None, "columns": None,
+                "error": f"数据源 {datasource_id} 不存在", "row_count": 0}
+
+    # 第一道闸：AST 只读校验
+    is_safe, err = _validate_readonly_sql(sql, ds.get("db_type", ""))
+    if not is_safe:
+        logger.warning("SQL 被安全护栏拒绝 [datasource=%s]: %s | SQL=%.200s",
+                       datasource_id, err, sql)
+        return {"success": False, "data": None, "columns": None,
+                "error": err, "row_count": 0}
+
+    # 行数硬上限：用户 limit 与全局 _QUERY_MAX_ROWS 取较小者
+    effective_limit = max(1, min(int(limit), _QUERY_MAX_ROWS))
+    # 仍保留字符串追加 LIMIT 兜底（用户未带 LIMIT 时，让 DB 端也只生成 effective_limit 行）
+    # 注意：sqlglot 校验已通过，原 SQL 不含 DML，追加 LIMIT 字符串不再引入绕过风险。
+    sql_upper = sql.upper()
+    if "LIMIT" not in sql_upper:
+        sql = sql.rstrip(";").rstrip() + f" LIMIT {effective_limit}"
 
     try:
         engine = get_engine(datasource_id)
-        with engine.connect() as conn:
+        with engine.connect().execution_options(timeout=_QUERY_TIMEOUT_SEC) as conn:
+            _apply_session_safety_limits(conn, ds.get("db_type", ""),
+                                          _QUERY_TIMEOUT_SEC)
             result = conn.execute(text(sql))
             columns = list(result.keys())
-            rows = [dict(zip(columns, row)) for row in result.fetchall()]
-            return {"success": True, "data": rows, "columns": columns, "error": None}
+            # 服务端 cursor 取数，避免 fetchall 把全表载入内存
+            rows_raw = result.fetchmany(effective_limit)
+            rows = [dict(zip(columns, row)) for row in rows_raw]
+            return {"success": True, "data": rows, "columns": columns,
+                    "error": None, "row_count": len(rows)}
     except Exception as e:
         logger.warning("SQL 执行失败 [datasource=%s]: %s", datasource_id, e)
         return {"success": False, "data": None, "columns": None,
-                "error": f"{type(e).__name__}: {e}"}
+                "error": f"{type(e).__name__}: {e}", "row_count": 0}
+
+
+def is_table_readable(datasource_id: str, table_name: str) -> bool:
+    """表名白名单校验：仅允许该数据源真实存在的表参与预览/拼接。
+
+    用于阻止路由参数 `table_name` 注入 `foo; DROP TABLE bar` 或
+    `information_schema.tables` 信息泄露——preview_table_data 路由
+    的 `SELECT * FROM {table_name}` 字符串拼接等价 SQL 注入通道。
+    """
+    if not table_name:
+        return False
+    # 严格白名单：必须为标识符（防 `; -- /` 等控制字符）
+    if any(c in table_name for c in ";'\"\\-/*@()\t\r\n "):
+        return False
+    try:
+        engine = get_engine(datasource_id)
+        inspector = inspect(engine)
+        existing = set(inspector.get_table_names())
+        # 视图也允许预览（部分库把视图列在 get_table_names 之外）
+        try:
+            existing |= set(inspector.get_view_names())
+        except Exception:
+            pass
+        return table_name in existing
+    except Exception as e:
+        logger.warning("表白名单校验失败 [datasource=%s, table=%s]: %s",
+                       datasource_id, table_name, e)
+        return False
+
+
+def quote_table_identifier(datasource_id: str, table_name: str) -> str:
+    """按数据源方言引用表名，避免标识符被解析为 SQL 控制符。
+
+    返回值仅在校验通过后使用：调用方必须先 is_table_readable 通过，
+    再用本函数拼 SQL。两者配合等价参数化但支持 identifier 绑定。
+    """
+    engine = get_engine(datasource_id)
+    preparer = engine.dialect.identifier_preparer
+    return preparer.quote_identifier(table_name)
 
 
 def test_connection(db_type: str, config: dict) -> tuple[bool, str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ from app.errors import register_exception_handlers
 from app.streaming import recover_conversations
 from app.routes import router as app_router
 
-APP_VERSION = os.environ.get("APP_VERSION", "0.13.0")
+APP_VERSION = os.environ.get("APP_VERSION", "0.13.1")
 log = get_logger("app.main")
 
 # 用户被标记 must_change_password 时仍可访问的接口：登录、改密、当前用户信息。

--- a/backend/app/routes/analyst.py
+++ b/backend/app/routes/analyst.py
@@ -280,12 +280,19 @@ async def preview_table_data(ds_id: str, table_name: str, limit: int = 10,
                              user: dict = Depends(auth.get_current_user)):
     """预览表数据：返回前 N 行数据，用于库表配置页确认字段含义（使用权限：owner/管理员/公共源可读）。
 
-    复用 datasource.manager.execute_query 跑 SELECT * LIMIT N。
+    安全：table_name 来自 URL 路径参数，不再直接 f-string 拼接到 SQL（防注入）。
+    先用 is_table_readable 在数据源元数据中做白名单校验（不存在即 404，
+    不区分"不存在"与"无权限"，避免越权探测），再用方言 identifier_preparer
+    引用标识符拼 SQL；下游 execute_query 仍会走 AST 校验作为第三道闸。
     """
     _require_usable(ds_id, user)
     try:
-        # 不同数据库的 LIMIT 语法不同，manager.execute_query 已对结果做了 limit 截断
-        sql = f"SELECT * FROM {table_name}"
+        if not ds_manager.is_table_readable(ds_id, table_name):
+            # 表不存在或 table_name 含注入字符，统一 404（不暴露存在性差异）
+            raise HTTPException(404, f"表 {table_name} 不存在")
+        # 白名单已通过，再用方言 identifier_preparer 加引号（双保险）
+        quoted = ds_manager.quote_table_identifier(ds_id, table_name)
+        sql = f"SELECT * FROM {quoted}"
         result = ds_manager.execute_query(ds_id, sql, limit=limit)
         return {
             "table_name": table_name,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,8 @@ SQLAlchemy==2.0.41
 jieba==0.42.1
 rank-bm25==0.2.2
 cryptography==45.0.5
+# SQL AST 解析：execute_query 只读校验，防多语句/CTE 改写 DML/危险函数绕过
+sqlglot==26.29.0
 # 表格问答（上传 Excel/CSV → DuckDB 查询）
 duckdb==1.5.5
 openpyxl==3.1.5

--- a/tests/test_analyst_datasource.py
+++ b/tests/test_analyst_datasource.py
@@ -497,3 +497,221 @@ def test_format_schema_text_skips_missing_table():
     # b 不在 table_info 中应被跳过，不抛错
     assert "表名: a" in text
     assert "b" not in text
+
+
+# ===========================================================================
+# SQL AST 只读校验：_validate_readonly_sql
+# ===========================================================================
+# 历史漏洞：startswith 关键词判断可被注释/括号/CTE 改写 DML 绕过。
+# 修复用 sqlglot AST 解析，这里覆盖关键绕过路径与正常通过路径。
+
+from app.agent.analyst.datasource.manager import _validate_readonly_sql
+
+
+@pytest.mark.parametrize("sql,db_type", [
+    ("SELECT * FROM customers", "sqlite"),
+    ("WITH cte AS (SELECT id FROM customers) SELECT * FROM cte", "sqlite"),
+    ("SELECT id, name FROM customers WHERE id > 0 ORDER BY id", "sqlite"),
+    ("SELECT COUNT(*) FROM orders", "sqlite"),
+    ("SELECT * FROM customers LIMIT 5", "sqlite"),
+])
+def test_validate_readonly_sql_accepts_safe_select(sql, db_type):
+    ok, err = _validate_readonly_sql(sql, db_type)
+    assert ok is True, f"应放行安全 SELECT: {sql} | 错误: {err}"
+
+
+@pytest.mark.parametrize("sql,db_type,expected_keyword", [
+    ("INSERT INTO customers VALUES (1,'x')", "sqlite", "INSERT"),
+    ("UPDATE customers SET name='x' WHERE id=1", "sqlite", "UPDATE"),
+    ("DELETE FROM customers WHERE id=1", "sqlite", "DELETE"),
+    ("DROP TABLE customers", "sqlite", "DROP"),
+    ("CREATE TABLE foo (id INT)", "sqlite", "CREATE"),
+    ("ALTER TABLE customers ADD COLUMN x INT", "sqlite", "ALTER"),
+    ("TRUNCATE TABLE customers", "sqlite", "TRUNCATE"),
+    # 注释前缀绕过：startswith 检查会被注释骗过，AST 检查不会
+    ("/* comment */ DROP TABLE customers", "sqlite", "DROP"),
+    ("-- line comment\nDROP TABLE customers", "sqlite", "DROP"),
+])
+def test_validate_readonly_sql_rejects_dml_ddl(sql, db_type, expected_keyword):
+    ok, err = _validate_readonly_sql(sql, db_type)
+    assert ok is False
+    assert expected_keyword in err.upper(), f"错误信息应含 {expected_keyword}，实际: {err}"
+
+
+def test_validate_readonly_sql_rejects_multistatement():
+    """多语句（stacked queries）拒绝——这是 startswith 时代最大的绕过漏洞。"""
+    ok, err = _validate_readonly_sql(
+        "SELECT * FROM customers; DROP TABLE customers", "sqlite")
+    assert ok is False
+    assert "多语句" in err or "stacked" in err.lower()
+
+
+def test_validate_readonly_sql_rejects_select_into():
+    """PG `SELECT ... INTO` 会建表，必须拒绝。"""
+    ok, err = _validate_readonly_sql(
+        "SELECT * INTO new_tbl FROM customers", "pg")
+    assert ok is False
+    # sqlglot 会把 SELECT INTO 重写为 CREATE，根节点判别拦下
+    assert "CREATE" in err.upper() or "INTO" in err.upper()
+
+
+def test_validate_readonly_sql_rejects_cte_with_dml_body():
+    """`WITH x AS (DELETE ...) SELECT` —— CTE 改写 DML 绕过路径。"""
+    ok, err = _validate_readonly_sql(
+        "WITH x AS (DELETE FROM customers RETURNING *) SELECT * FROM x", "pg")
+    assert ok is False
+    assert "CTE" in err
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT pg_terminate_backend(1)",
+    "SELECT pg_sleep(10)",
+    "SELECT sleep(5)",
+    "SELECT load_file('/etc/passwd')",
+    "SELECT benchmark(1000000, MD5('x'))",
+])
+def test_validate_readonly_sql_rejects_dangerous_functions(sql):
+    ok, err = _validate_readonly_sql(sql, "mysql")
+    assert ok is False
+    assert "禁止调用函数" in err or "安全限制" in err
+
+
+def test_validate_readonly_sql_rejects_empty():
+    assert _validate_readonly_sql("", "sqlite")[0] is False
+    assert _validate_readonly_sql("   ", "sqlite")[0] is False
+
+
+def test_validate_readonly_sql_rejects_syntax_error():
+    """语法错误的 SQL 应 fail-closed（拒绝而非放行）。"""
+    ok, err = _validate_readonly_sql("SELECT FROM WHERE", "sqlite")
+    assert ok is False
+    assert "解析失败" in err or "语法" in err
+
+
+# ===========================================================================
+# execute_query 集成：AST 校验 + fetchmany 行数硬上限
+# ===========================================================================
+
+def test_execute_query_rejects_multistatement(monkeypatch, tmp_path):
+    """execute_query 入口应拦截多语句 SQL。"""
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    result = ds_manager.execute_query(
+        ds["id"], "SELECT * FROM customers; DROP TABLE customers")
+    assert result["success"] is False
+    assert "多语句" in result["error"] or "stacked" in result["error"].lower()
+
+
+def test_execute_query_rejects_select_into(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    # sqlite 不支持 SELECT INTO 但 sqlglot 会重写为 CREATE，AST 层就拦下
+    result = ds_manager.execute_query(
+        ds["id"], "SELECT * INTO new_tbl FROM customers")
+    assert result["success"] is False
+    assert "CREATE" in result["error"].upper() or "INTO" in result["error"].upper()
+
+
+def test_execute_query_rejects_dangerous_function(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    result = ds_manager.execute_query(ds["id"], "SELECT sleep(10)")
+    assert result["success"] is False
+    assert "禁止调用函数" in result["error"]
+
+
+def test_execute_query_fetchmany_caps_rows_at_global_max(monkeypatch, tmp_path):
+    """limit 超过 _QUERY_MAX_ROWS 时应被硬上限截断。"""
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    # 把全局上限调小到 1，验证 fetchmany 真的只取 1 行
+    monkeypatch.setattr(ds_manager, "_QUERY_MAX_ROWS", 1)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    # 用户传 limit=100，但全局上限 1 应该赢
+    result = ds_manager.execute_query(
+        ds["id"], "SELECT * FROM customers", limit=100)
+    assert result["success"] is True
+    assert result["row_count"] == 1
+    assert len(result["data"]) == 1
+
+
+def test_execute_query_respects_user_limit_below_max(monkeypatch, tmp_path):
+    """limit 在 _QUERY_MAX_ROWS 以内时按用户 limit 返回。"""
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    monkeypatch.setattr(ds_manager, "_QUERY_MAX_ROWS", 1000)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    result = ds_manager.execute_query(
+        ds["id"], "SELECT * FROM customers", limit=1)
+    assert result["success"] is True
+    assert result["row_count"] == 1
+
+
+# ===========================================================================
+# is_table_readable 表名白名单：preview_table_data 路由的 SQL 注入防御
+# ===========================================================================
+
+def test_is_table_readable_returns_true_for_existing_table(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    assert ds_manager.is_table_readable(ds["id"], "customers") is True
+    assert ds_manager.is_table_readable(ds["id"], "orders") is True
+
+
+def test_is_table_readable_returns_false_for_nonexistent_table(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    assert ds_manager.is_table_readable(ds["id"], "no_such_table") is False
+
+
+@pytest.mark.parametrize("malicious_table_name", [
+    "customers; DROP TABLE customers",
+    "customers WHERE 1=1",
+    "customers--",
+    "customers /* comment */",
+    "information_schema.tables",
+    "customers' OR '1'='1",
+    "customers UNION SELECT * FROM orders",
+    "customers; --",
+])
+def test_is_table_readable_rejects_injection_strings(monkeypatch, tmp_path,
+                                                     malicious_table_name):
+    """table_name 含 SQL 注入字符的应一律拒绝。"""
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    assert ds_manager.is_table_readable(ds["id"], malicious_table_name) is False
+
+
+def test_quote_table_identifier_quotes_correctly(monkeypatch, tmp_path):
+    """quote_table_identifier 应用方言标识符引用，避免被解析为 SQL 控制符。"""
+    monkeypatch.setenv("ANALYST_DB_KEY", "test-key-for-analyst-0123456789")
+    monkeypatch.setattr(ds_manager, "_CIPHER_KEY", None)
+    ds = ds_manager.create_datasource(_make_ds_data(name="DS"))
+    _inject_sqlite_engine(monkeypatch, tmp_path, ds["id"])
+
+    quoted = ds_manager.quote_table_identifier(ds["id"], "customers")
+    # SQLite 引用形式是 "customers"（双引号）
+    assert "customers" in quoted
+    assert quoted != "customers"  # 应被引用符包裹，不等于裸标识符


### PR DESCRIPTION
## 概述

修复数据分析员工的 SQL 只读校验存在多条绕过路径（CTE 改写 DML / 多语句 / 注释前缀 / SELECT INTO / 危险函数），以及表预览路由 `f"SELECT * FROM {table_name}"` 字符串拼接等价 SQL 注入通道的问题。按 [代码评审建议](https://github.com/zj-unicom-ai/UniEmployee) 优先级 4→1→2→3 落地（只读数据库账号需 DBA 配合，留下一迭代）。

## 变更

### 1. 表预览 table_name 白名单（最快堵漏）

- 新增 [`is_table_readable(ds_id, table_name)`](backend/app/agent/analyst/datasource/manager.py)：先字符级防注入字符（`; ' " \\ - / * @ ( ) \t \r \n 空格`），再 `inspector.get_table_names / get_view_names` 校验真实存在，不存在返回 False
- 新增 [`quote_table_identifier(ds_id, table_name)`](backend/app/agent/analyst/datasource/manager.py)：用方言 `identifier_preparer.quote_identifier` 引用标识符
- [`analyst.py::preview_table_data`](backend/app/routes/analyst.py) 改为「白名单 + 引用」双闸，不再 f-string 拼接裸标识符

### 2. execute_query AST 只读校验

- 引入 `sqlglot==26.29.0`（纯 Python，无 C 扩展），按数据源方言解析 SQL
- [`_validate_readonly_sql`](backend/app/agent/analyst/datasource/manager.py)：多语句拒绝 / 根节点必须 SELECT / CTE 体只允许 SELECT / SELECT INTO 拒绝 / 危险函数黑名单（pg_terminate_backend / pg_sleep / load_file / sleep / benchmark / sys_exec / xp_cmdshell 等）
- 解析失败 fail-closed（拒绝而非放行）

### 3. 查询超时 + 行数硬上限

- 服务端 `fetchmany(min(limit, _QUERY_MAX_ROWS))` 取代 `fetchall`，杜绝全表载入内存
- 用户 limit 与全局 `ANALYST_QUERY_MAX_ROWS`（默认 1000，env 可覆盖）取较小者
- PG `SET LOCAL statement_timeout` / MySQL `SET SESSION MAX_EXECUTION_TIME`，可通过 `ANALYST_QUERY_TIMEOUT_SEC`（默认 30s）覆盖
- 其他方言退化到 SQLAlchemy `execution_options(timeout=)` 客户端 cancel
- 超时设置失败不阻断（仅日志）

## 验证清单

- [x] 新增 40 个单元测试覆盖关键绕过路径（多语句 / CTE 改写 DML / SELECT INTO / 危险函数 / 注释前缀 DROP / SQL 语法错误 fail-closed / fetchmany 全局行数硬上限 / is_table_readable 拒 8 类注入字符串）
- [x] analyst 全套 193 个测试通过：`PYTHONPATH=backend .venv/bin/python -m pytest tests/test_analyst_*.py`
- [x] 其他模块未回归（isolation/security/assignment/browser 失败在 main 上同存，与本次无关，已对比验证）
- [x] 前端构建通过：`cd frontend && npx vite build`
- [x] CHANGELOG 加 0.13.1 条目；APP_VERSION 默认值 0.13.0 → 0.13.1

## 后续（不在本 PR 范围）

- 只读数据库账号：需 DBA 配合，建议下一迭代在数据源配置里增加 `readonly_account` 字段
- sql_db_query 工具的 user SQL 入口同样受 AST 校验保护，无需额外改动
- frontend/package.json 仍是 0.12.0（落后 main.py），版本号同步问题与本次修复无关