### PR TITLE
fix(ui): 修复侧边栏栏目点击无反应 (v0.13.0 回归)

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -88,6 +88,15 @@ const route = useRoute()
 const auth = useAuthStore()
 const collapsed = ref(false)
 
+// 系统设置受控展开：切到非系统设置栏目时自动收起父项，
+// 避免父项一直占空间。包含父项 key 和所有子项 key。
+const SETTINGS_GROUP_KEYS = [
+  'settings', 'guard-words', 'guard-tools',
+  'im', 'model-manager', 'audit-logs',
+]
+// 默认收起；切到系统设置子项时由 onMenuSelect 展开
+const expandedKeys = ref([])
+
 function iconEl(svg) {
   return () => h(NIcon, null, {
     default: () => h('svg', { width: '18', height: '18', viewBox: '0 0 24 24', fill: 'none', innerHTML: svg })
@@ -179,8 +188,10 @@ function onMenuSelect(key) {
     router.push({ name: 'landing' })
     return
   }
-  // 切到非系统设置范围内的栏目时，自动收起系统设置父项
-  if (!SETTINGS_GROUP_KEYS.includes(key)) {
+  // 切到系统设置子项时展开父项；切到其他栏目时收起，避免占空间
+  if (SETTINGS_GROUP_KEYS.includes(key) && key !== 'settings') {
+    expandedKeys.value = ['settings']
+  } else if (key !== 'settings') {
     expandedKeys.value = []
   }
   if (key !== 'change-password') {


### PR DESCRIPTION
## 概述

v0.13.0 PR #34 引入「系统设置」子菜单受控展开（`v-model:expanded-keys`）时漏写了两处声明，导致 `onMenuSelect` 一执行就抛 `ReferenceError`，**所有栏目点击都无反应**（路由不跳转）。

## 根因

[`MainLayout.vue::onMenuSelect`](frontend/src/layouts/MainLayout.vue#L186) 引用了：

- `SETTINGS_GROUP_KEYS` —— 未声明，访问即抛 `ReferenceError: SETTINGS_GROUP_KEYS is not defined`
- `expandedKeys.value = []` —— `expandedKeys` 也未声明为 ref

两个 undefined 一访问就抛，`router.push` 永远到不了。

## 修复

补两处声明（[`MainLayout.vue:91-98`](frontend/src/layouts/MainLayout.vue#L91-L98)）：

\`\`\`js
const SETTINGS_GROUP_KEYS = [
  'settings', 'guard-words', 'guard-tools',
  'im', 'model-manager', 'audit-logs',
]
const expandedKeys = ref([])
\`\`\`

同时修正 `onMenuSelect` 逻辑：切到系统设置子项时展开父项，切到其他栏目时收起。

## 验证

- [x] `cd frontend && npx vite build` 通过
- [x] 本地构建无报错（运行时验证需用户点页面确认）