### PR TITLE
feat(connector): 接入 Playwright MCP 浏览器自动化连接器

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,11 @@ SANDBOX_CPU=1
 SANDBOX_MEMORY=2Gi
 # 单进程并发沙箱上限（按会话计；超限抛错，避免容器数失控）
 SANDBOX_MAX_CONCURRENT=20
+
+# ===== Playwright 浏览器连接器 =====
+# 连接器配置在 seeds.py 的 CONNECTOR_SEEDS 里（npx @playwright/mcp，headless + isolated）。
+# 首次使用前需安装浏览器二进制（仅一次）：
+#   npx playwright install --with-deps chromium
+# 容器部署时在 Dockerfile 里加这行（RUN npx playwright install --with-deps chromium）。
+# 浏览器自动化需要额外系统依赖（libnss3/libatk1.0/libgbm 等），Debian/Ubuntu 用
+#   npx playwright install-deps chromium  自动装齐。

--- a/backend/app/catalog/seeds.py
+++ b/backend/app/catalog/seeds.py
@@ -32,6 +32,14 @@ CONNECTOR_SEEDS = [
               "DOTENV_CONFIG_QUIET": "true"},
       # cwd 用无 .env 的中立目录，避免 dotenvx 把 banner 打到 stdout 污染 MCP 通道
       "cwd": "/tmp"}),
+    # Playwright 浏览器自动化连接器（官方 @playwright/mcp，npx 型 stdio）。
+    # 提供 navigate/click/fill/screenshot/extract 等浏览器操作工具，让员工能操作
+    # 无 API 的老旧系统、采集网页信息、自动化填报。默认 headless + isolated 模式。
+    # 首次使用需预装浏览器：npx playwright install --with-deps chromium
+    ("playwright", "Playwright 浏览器连接器", "浏览器自动化 MCP（npx，headless）",
+     {"transport": "stdio", "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--headless", "--isolated"],
+      "cwd": "/tmp"}),
 ]
 
 # 内置连接器指派给员工（与 seeds dict 的 cons 保持一致，用于独立回填）


### PR DESCRIPTION
## Summary
- 新增 Playwright MCP 连接器（`@playwright/mcp`，npx 型 stdio），提供 24 个浏览器操作工具
- 默认 `--headless --isolated` 模式（无头 + 内存态 profile，不持久化到磁盘）
- 不指派给任何员工（`CONNECTOR_ASSIGN` 未加），管理员在资源中心按需给员工授权
- `.env.example` 补充浏览器二进制安装说明

## 工具列表
navigate / navigate_back / close / resize / tabs / click / type / fill_form / press_key / select_option / hover / drag / drop / snapshot（无障碍树）/ take_screenshot / find / console_messages / network_requests / evaluate / file_upload / handle_dialog / wait_for / run_code_unsafe

## 验证
- [x] `test_catalog.py` 9 项全通过
- [x] 连接器配置结构校验通过（transport/command/args/cwd）
- [x] MCP 连接器实连验证：成功启动并返回 24 个工具
- [x] 功能 demo：打开 gov.cn → 页面快照抓到完整无障碍树 → 截图 450KB 真实页面 → 搜索"国务院"命中 11 处