### PR TITLE
fix(ci): 后端测试流水线修复——补 pandas 依赖 + 摘要测试适配 deepagents 0.7.13

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,6 +27,7 @@ cryptography==45.0.5
 sqlglot==26.29.0
 # 表格问答（上传 Excel/CSV → DuckDB 查询）
 duckdb==1.5.5
+pandas==3.0.5
 openpyxl==3.1.5
 # OpenSandbox 沙箱执行环境（backend=sandbox 员工；SANDBOX_ENABLED=1 启用）
 opensandbox==0.1.16

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -29,7 +29,9 @@ class FakeModel(BaseChatModel):
     def _generate(self, messages, stop=None, run_manager=None, **kwargs):
         return ChatResult(generations=[ChatGeneration(message=AIMessage(content="FAKE_SUMMARY"))])
 
-    async def ainvoke(self, input, **kwargs):
+    async def ainvoke(self, input, config=None, **kwargs):
+        # langchain_core 的 RunnableBinding 会把 config 作为第二个位置参数透传，
+        # 签名必须与 BaseChatModel.ainvoke(input, config=None, **kwargs) 兼容
         return AIMessage(content="FAKE_SUMMARY")
 
 
@@ -103,8 +105,11 @@ def test_summary_generation_and_offload(tmp_path):
     summary = asyncio.run(mw._acreate_summary(to_summarize))
     assert summary == "FAKE_SUMMARY"
 
-    path = mw._offload_to_backend(backend, to_summarize)
-    assert path and path.startswith("/conversation_history/") and path.endswith(".md")
+    # deepagents 0.7.13 起 _offload_to_backend 需要 session_id（每会话一个追加文件）
+    session_id = mw._get_session_id({})
+    path = mw._offload_to_backend(backend, to_summarize, session_id)
+    assert path == mw._get_history_path(session_id)
+    assert path.startswith("/conversation_history/") and path.endswith(".md")
     resp = backend.download_files([path])
     assert resp[0].content is not None
     assert "问题0" in resp[0].content.decode("utf-8")


### PR DESCRIPTION
## 变更内容

main 已连续 3 次 CI 红灯（#38 / v0.14.0 / #39），根因有两个：

1. **pandas 依赖漏声明（17 个测试模块收集失败）**
   - `backend/app/agent/analyst/fileqa/manager.py` 直接 `import pandas`，但 `backend/requirements.txt` 只有 duckdb、没有 pandas（仅存在于 requirements.lock.txt）
   - 本地 venv 恰好装过 pandas 所以一直没暴露；CI 干净环境 `ModuleNotFoundError: No module named 'pandas'`，连锁导致 compiler / mcp / subagents 等 17 个模块收集失败
   - 修复：requirements.txt 补 `pandas==3.0.5`（与 lock 文件一致）

2. **test_summarization 在 pandas 修好后会接着失败（框架签名漂移）**
   - `FakeModel.ainvoke(input, **kwargs)` 与 langchain_core 1.6.3 不兼容：`RunnableBinding` 把 config 作为第二个位置参数透传 → `takes 2 positional arguments but 3 were given`
   - `_offload_to_backend()` 在 deepagents 0.7.13 新增必填 `session_id` 参数（每会话一个追加历史文件）
   - 修复：FakeModel 签名改为 `(input, config=None, **kwargs)`；测试改用 `_get_session_id({})` + `_get_history_path()` 走新 API

## 验证

- [x] `pytest tests/ --collect-only` 退出码 0（此前 17 errors）
- [x] 受影响 18 个模块（含 test_summarization 7 用例）本地全部通过
- [ ] CI 后端测试转绿（以 PR check 为准）
- [x] 无前端改动，前端构建不受影响

## 备注

- 纯 CI/测试修复，不改运行时代码逻辑
- 合并后 PR #40（开发者指南文档）rebase main 即可转绿