### PR TITLE
feat(ontology): 企业业务本体对话写回（ontology_write）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.15.0 (2026-09-13)
+
+### 新增：企业业务本体对话写回（ontology_write）——本体深化阶段 1 第一项
+
+- **对话即录入**：新增闭包工具 `ontology_write`，员工可在对话中把用户明确陈述的业务事实写回企业本体（全企业共享），支持三种操作：
+  - `create_entity` 新增实体（同名查重，已存在则提示走更新，不重复建）
+  - `update_entity` 增量更新（props 按 key 浅合并不抹其他字段，区别于管理端整包覆盖）
+  - `create_relation` 建立关系边（端点可用 id 或「类型+名称」指定，名称自动解析、歧义报错；复用既有 schema 两端类型校验；同类型重边幂等去重）
+- **授权红线**：写回是独立工具授权，未在资源中心勾选的员工编译时根本不注入该工具（模型无法调用）；system prompt 的写回规程也按授权挂载。默认仅授权 xiaoxiao（客户事实）与 hrbp（员工事实），老库由 `backfill_ontology_tools()` 幂等补登记/补指派，其余内置员工不补
+- **数据溯源 + 审计**：entities/relations 新增 `source`（seed/admin/chat/import）、`source_ref`（来源会话 id，取自运行时 thread_id）、`created_by`（操作人）三列，老库启动幂等 ALTER 补列、存量数据标 seed；每次写回写 catalog 审计日志（chat_create_entity/chat_update_entity/chat_create_relation，含 before/after 快照），幂等重边不重复审计
+- 管理端既有 CRUD 的写入默认标 source=admin；资源中心工具列表自动出现「企业本体写回」开关，无需前端改动
+- 招牌演示：对 HRBP 说「记一下，王工升职为信息化部副总监」→ 下一轮问「王工什么职位」，答案来自本体而非模型记忆
+
+### 测试
+
+- 新增 7 个用例：迁移幂等与 seed 溯源默认值、props 合并更新与溯源落标、名称解析（精确/模糊唯一/歧义/未命中）、关系写回去重、工具授权闸门、工具级全流程（新增→查重拒绝→合并更新→按名建边→schema 拒绝→审计齐全）、跨租户写回隔离
+- 编译器接线冒烟：授权员工实际装配 ontology_write 且 system prompt 挂写回规程，未授权员工不注入
+- 全量 pytest：新增用例全绿，失败清单与 main 基线一致（均为既有登录 401/429、playwright 类环境失败）
+
 ## 0.14.1 (2026-09-12)
 
 ### 新增：市场情报数字员工「小察」（market-intel）

--- a/backend/app/catalog/seeds.py
+++ b/backend/app/catalog/seeds.py
@@ -49,6 +49,12 @@ CONNECTOR_ASSIGN = {"crm": ["xiaoxiao", "hrbp"], "newsnow": ["xiaoshu", "market-
 # 内置员工默认启用的本体查询工具（业务事实问答依赖，资源中心可见可开关）
 ONTOLOGY_TOOLS = ("ontology_find_entities", "ontology_query_relations")
 
+# 本体写回工具（对话中增改实体/建立关系）：独立授权，默认只给掌握业务事实
+# 录入职责的员工（xiaoxiao 客户事实 / hrbp 员工事实）；资源中心可开关，
+# 未授权员工编译时不注入该工具。
+ONTOLOGY_WRITE_TOOL = "ontology_write"
+ONTOLOGY_WRITE_EMPLOYEES = ("xiaoxiao", "hrbp")
+
 # 数据分析专家 xiaoshu 的 SQL 工具集（agent/analyst 模块定义，登记进 tools 表
 # 后资源中心可见可开关；老库由 backfill_analyst_sql_tools 幂等补缺）
 ANALYST_SQL_TOOLS = {
@@ -73,9 +79,15 @@ ANALYST_FILE_TOOLS = {
 }
 
 
-def _tools_with_ontology(tools: list[str]) -> list[str]:
-    """种子员工统一追加本体查询工具，让新库播种时默认具备业务事实问答能力。"""
-    return tools + list(ONTOLOGY_TOOLS)
+def _tools_with_ontology(tools: list[str], write: bool = False) -> list[str]:
+    """种子员工统一追加本体查询工具，让新库播种时默认具备业务事实问答能力。
+
+    write=True 时再追加 ontology_write（对话写回），仅业务事实录入岗使用。
+    """
+    out = tools + list(ONTOLOGY_TOOLS)
+    if write:
+        out.append(ONTOLOGY_WRITE_TOOL)
+    return out
 
 
 # 算网运营 SOP 种子（seed_if_empty 全量播种 / backfill_netops_upgrade 老库补缺共用）
@@ -159,11 +171,11 @@ EMPLOYEE_SEEDS = {
         kbs=[], sops=[]),
     "xiaoxiao": dict(
         skills=["enterprise-sales", "customer-360", "renewal-scan"],
-        tools=_tools_with_ontology(["kb_search", "bocha_search", "create_ticket"]),
+        tools=_tools_with_ontology(["kb_search", "bocha_search", "create_ticket"], write=True),
         kbs=[]),
     "hrbp": dict(
         skills=["hr-assistant"],
-        tools=_tools_with_ontology(["kb_search", "create_ticket", "bocha_search"]),
+        tools=_tools_with_ontology(["kb_search", "create_ticket", "bocha_search"], write=True),
         kbs=[]),
     "biz-analyzer": dict(
         skills=["business-overview", "root-cause-analysis",
@@ -227,6 +239,9 @@ def seed_if_empty():
          "按实体类型/关键词查询企业业务实体（组织/员工/客户/项目/合同/订单等）", "local", None),
         ("ontology_query_relations", "企业本体关系查询",
          "查询企业实体间的业务关系（谁负责/跟进/下单/包含等）", "local", None),
+        ("ontology_write", "企业本体写回",
+         "对话中把用户确认的业务事实写回企业本体（新增/更新实体、建立关系，仅授权员工）",
+         "local", None),
         # 数据分析专家 SQL 工具集（与 ANALYST_SQL_TOOLS 常量保持一致）
         ("sql_db_smart_search", "智能表检索",
          "BM25 检索最相关的表并返回 schema（数据分析首选工具）", "local", None),
@@ -334,8 +349,10 @@ def backfill_ontology_tools():
                                    "按实体类型/关键词查询企业业务实体（组织/员工/客户/项目/合同/订单等）"),
         "ontology_query_relations": ("企业本体关系查询",
                                      "查询企业实体间的业务关系（谁负责/跟进/下单/包含等）"),
+        ONTOLOGY_WRITE_TOOL: ("企业本体写回",
+                              "对话中把用户确认的业务事实写回企业本体（新增/更新实体、建立关系，仅授权员工）"),
     }
-    for tid in ONTOLOGY_TOOLS:
+    for tid in (*ONTOLOGY_TOOLS, ONTOLOGY_WRITE_TOOL):
         name, desc = _ONTOLOGY_DESC[tid]
         cur.execute(
             "INSERT OR IGNORE INTO tools(id,name,description,source,needs_approval) "
@@ -346,6 +363,13 @@ def backfill_ontology_tools():
                        (e,)).fetchone():
             for t in ONTOLOGY_TOOLS:
                 cur.execute("INSERT OR IGNORE INTO employee_tools VALUES(?,?)", (e, t))
+    # 写回是独立授权：只给业务事实录入岗（xiaoxiao/hrbp），其余内置员工不补。
+    for e in ONTOLOGY_WRITE_EMPLOYEES:
+        if cur.execute("SELECT 1 FROM employees WHERE id=? AND deleted_at IS NULL",
+                       (e,)).fetchone():
+            cur.execute(
+                "INSERT OR IGNORE INTO employee_tools VALUES(?,?)",
+                (e, ONTOLOGY_WRITE_TOOL))
     con.commit()
     con.close()
 

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -181,12 +181,12 @@ def _build_sop_routing(sops: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _build_ontology_routing() -> str:
-    """企业业务本体使用指引：所有员工都具备 ontology_* 查询工具。
+def _build_ontology_routing(write_enabled: bool = False) -> str:
+    """企业业务本体使用指引：员工具备 ontology_* 工具时拼进 system_prompt。
 
     本体的价值是让数字员工基于真实业务关系作答（谁负责哪个项目、
-    哪个客户下过哪些订单），而不是靠模型猜测。拼进 system_prompt，
-    确保模型在用户问业务事实时先查本体。
+    哪个客户下过哪些订单），而不是靠模型猜测。
+    write_enabled=True 时额外挂载写回规程（仅授权 ontology_write 的员工）。
     """
     lines = [
         "",
@@ -197,8 +197,19 @@ def _build_ontology_routing() -> str:
         "- 查关系：ontology_query_relations（如谁负责某项目、某客户下过哪些订单、某订单包含哪些产品）",
         "查询链路：先 ontology_find_entities 拿到实体 id，再 ontology_query_relations 沿关系展开。",
         "例如用户问「李晓芳负责哪些项目」：先查员工李晓芳，再用她的 id 查询 manage 关系。",
-        "",
     ]
+    if write_enabled:
+        lines += [
+            "",
+            "### 业务事实写回（ontology_write，谨慎使用）",
+            "用户明确要求「记一下/记录/更新/新增/把…录到本体/建立…关系」时，把确认无误的事实写回本体——",
+            "本体是全企业共享的结构化事实，其他数字员工都会读到，写入纪律：",
+            "1. 只写用户亲口陈述、语义明确的事实；禁止推测补全，信息不全先追问确认后再写；",
+            "2. 写前先 ontology_find_entities 查重：已存在的实体用 update_entity（属性合并），不要重复新建；",
+            "3. 关系端点优先用名称+类型让工具自动解析，解析歧义时按返回的候选列表向用户确认；",
+            "4. 写回成功后明确告知用户「已记录」及具体内容；工具返回 ok=false 时不得谎称成功。",
+        ]
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -306,11 +317,18 @@ async def _assemble_tools(spec: EmployeeSpec, checkpointer=None,
             tools.append(ALL_LOCAL_TOOLS[g])
 
     # --- 企业业务本体闭包工具：spec.tools 声明了 ontology_* 才注入（按用户 tenant 隔离）。
-    #     与 kb_search 同理，是闭包工具不进 ALL_LOCAL_TOOLS；声明任一即注入两个，
-    #     配合使用（find 拿 id → query_relations 展开）。资源中心可对员工开关。---
+    #     与 kb_search 同理，是闭包工具不进 ALL_LOCAL_TOOLS；声明任一查询工具即注入
+    #     两个只读工具（find 拿 id → query_relations 展开）。
+    #     ontology_write（企业本体写回）是独立授权：只有 spec.tools 显式声明才注入，
+    #     未授权员工的工具集里不存在该工具（资源中心开关即授权）；授权写回时连带
+    #     保证只读工具在场（写之前需要 find 定位实体）。---
     from app.tools.ontology_tools import make_ontology_tools
-    if any(n in ("ontology_find_entities", "ontology_query_relations") for n in spec.tools):
-        for t in make_ontology_tools(user_id):
+    onto_reads = any(n in ("ontology_find_entities", "ontology_query_relations")
+                     for n in spec.tools)
+    onto_write = "ontology_write" in spec.tools
+    if onto_reads or onto_write:
+        for t in make_ontology_tools(user_id, include_reads=onto_reads or onto_write,
+                                     include_write=onto_write):
             if t.name not in have:
                 tools.append(t)
 
@@ -514,8 +532,10 @@ async def compile_agent(spec: EmployeeSpec, checkpointer, store, user_id: str | 
     system_prompt += _build_user_context(user_id)
     system_prompt += _build_skill_routing(skill_summaries)
     system_prompt += _build_sop_routing(sop_summaries)
-    if any(n in ("ontology_find_entities", "ontology_query_relations") for n in spec.tools):
-        system_prompt += _build_ontology_routing()
+    if any(n in ("ontology_find_entities", "ontology_query_relations", "ontology_write")
+           for n in spec.tools):
+        system_prompt += _build_ontology_routing(
+            write_enabled="ontology_write" in spec.tools)
     system_prompt += _build_subagent_routing(subagents)
     if spec.subagent_policy:
         system_prompt += "\n" + spec.subagent_policy.strip()

--- a/backend/app/ontology.py
+++ b/backend/app/ontology.py
@@ -3,7 +3,11 @@
 设计要点：
 - 通用 schema：类型表存元结构（attrs 为 JSON 数组），实例表存 JSON 属性，不预判业务字段。
 - 两层隔离：schema 层 system 租户预置 + 各租户可自定义；data 层按 tenant_id 隔离。
-- 运行时工具（ontology_find_entities / ontology_query_relations）只做业务事实查询。
+- 运行时工具：ontology_find_entities / ontology_query_relations 只读查询，
+  ontology_write 为对话写回（仅授权员工装配，见 tools/ontology_tools.py）。
+- 数据溯源：entities/relations 的 source 列区分来源
+  （seed=系统种子 / admin=管理端录入 / chat=对话写回 / import=文档导入），
+  source_ref 记录来源会话等引用，created_by 记录操作人，配合审计日志追溯。
 """
 
 import json
@@ -16,6 +20,12 @@ from app.paths import db_path
 
 ROOT = Path(__file__).resolve().parent.parent.parent  # backend/
 DB = db_path("ontology.db")
+
+# 数据来源标记
+SOURCE_SEED = "seed"
+SOURCE_ADMIN = "admin"
+SOURCE_CHAT = "chat"
+SOURCE_IMPORT = "import"
 
 
 def _conn():
@@ -64,6 +74,9 @@ def init():
       name TEXT NOT NULL,
       props TEXT DEFAULT '{}',
       tenant_id TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'seed',
+      source_ref TEXT,
+      created_by TEXT,
       created_at TEXT, updated_at TEXT, deleted_at TEXT);
     CREATE TABLE IF NOT EXISTS relations(
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -72,14 +85,34 @@ def init():
       relation_type TEXT NOT NULL,
       props TEXT DEFAULT '{}',
       tenant_id TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'seed',
+      source_ref TEXT,
+      created_by TEXT,
       created_at TEXT, updated_at TEXT, deleted_at TEXT);
     CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(entity_type);
     CREATE INDEX IF NOT EXISTS idx_entities_tenant ON entities(tenant_id);
     CREATE INDEX IF NOT EXISTS idx_relations_from ON relations(from_id);
     CREATE INDEX IF NOT EXISTS idx_relations_to ON relations(to_id);
     """)
+    _migrate_source_columns(con)
     con.commit()
     con.close()
+
+
+def _migrate_source_columns(con):
+    """老库补 source/source_ref/created_by 三列（数据溯源，幂等）。
+
+    存量数据统一视为 seed（系统种子/历史录入），新增写回数据才标 chat/admin。
+    """
+    for table in ("entities", "relations"):
+        cols = dblayer.table_columns(con, table)
+        if "source" not in cols:
+            con.execute(
+                f"ALTER TABLE {table} ADD COLUMN source TEXT NOT NULL DEFAULT 'seed'")
+        if "source_ref" not in cols:
+            con.execute(f"ALTER TABLE {table} ADD COLUMN source_ref TEXT")
+        if "created_by" not in cols:
+            con.execute(f"ALTER TABLE {table} ADD COLUMN created_by TEXT")
 
 
 # ---------------- 种子数据 ----------------
@@ -720,7 +753,8 @@ def get_entity(tenant_id: str, id_: int) -> dict | None:
     return _row_to_dict(row) if row else None
 
 
-def create_entity(tenant_id: str, data: dict) -> int:
+def create_entity(tenant_id: str, data: dict, *, source: str = SOURCE_ADMIN,
+                  source_ref: str | None = None, created_by: str | None = None) -> int:
     type_, name = (data.get("entity_type") or "").strip(), (data.get("name") or "").strip()
     if not type_ or not name:
         raise ValueError("entity_type 与 name 必填")
@@ -733,26 +767,92 @@ def create_entity(tenant_id: str, data: dict) -> int:
     try:
         rid = dblayer.insert_returning_id(
             con,
-            "INSERT INTO entities(entity_type,name,props,tenant_id,created_at,updated_at)"
-            " VALUES(?,?,?,?,?,?)",
-            (type_, name, props, tenant_id, now, now))
+            "INSERT INTO entities(entity_type,name,props,tenant_id,source,source_ref,"
+            "created_by,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?)",
+            (type_, name, props, tenant_id, source, source_ref, created_by, now, now))
         con.commit()
         return rid
     finally:
         con.close()
 
 
-def update_entity(tenant_id: str, id_: int, data: dict) -> None:
+def update_entity(tenant_id: str, id_: int, data: dict, *, source: str = SOURCE_ADMIN,
+                  source_ref: str | None = None, created_by: str | None = None) -> None:
     props = json.dumps(data.get("props") or {}, ensure_ascii=False)
     con = _conn()
     if not _type_visible(con, "entity_types", data.get("entity_type") or "", tenant_id):
         con.close()
         raise ValueError(f"实体类型 {data.get('entity_type')} 不存在")
     con.execute(
-        "UPDATE entities SET entity_type=?, name=?, props=?, updated_at=? WHERE id=? AND tenant_id=?",
-        (data.get("entity_type"), data.get("name"), props, _now(), id_, tenant_id))
+        "UPDATE entities SET entity_type=?, name=?, props=?, source=?, source_ref=?, "
+        "created_by=?, updated_at=? WHERE id=? AND tenant_id=?",
+        (data.get("entity_type"), data.get("name"), props, source, source_ref,
+         created_by, _now(), id_, tenant_id))
     con.commit()
     con.close()
+
+
+def resolve_entity(tenant_id: str, entity_type: str, name: str) -> dict:
+    """按名称解析唯一实体（对话写回时用名称指定端点）：
+
+    - 精确同名优先；
+    - 无精确命中时做唯一包含匹配（忽略大小写），命中多个则歧义报错；
+    - 0 个或多个候选均抛 ValueError，由调用方把候选反馈给模型/用户。
+    """
+    name = (name or "").strip()
+    type_ = (entity_type or "").strip()
+    if not type_ or not name:
+        raise ValueError("entity_type 与 name 必填")
+    con = _conn()
+    exact = con.execute(
+        "SELECT * FROM entities WHERE tenant_id=? AND entity_type=? AND name=? "
+        "AND deleted_at IS NULL", (tenant_id, type_, name)).fetchall()
+    if len(exact) == 1:
+        con.close()
+        return _row_to_dict(exact[0])
+    rows = con.execute(
+        "SELECT * FROM entities WHERE tenant_id=? AND entity_type=? AND deleted_at IS NULL "
+        "AND LOWER(name) LIKE ? ORDER BY id",
+        (tenant_id, type_, f"%{name.lower()}%")).fetchall()
+    con.close()
+    if len(rows) == 1:
+        return _row_to_dict(rows[0])
+    if not rows:
+        raise ValueError(f"未找到 {type_} 类型中名为「{name}」的实体，请先用 ontology_find_entities 确认")
+    names = "、".join(r["name"] for r in rows[:10])
+    raise ValueError(f"名称「{name}」匹配到多个 {type_}（{names}），请改用实体 id 指定")
+
+
+def patch_entity(tenant_id: str, id_: int, props: dict | None = None,
+                 name: str | None = None, *, source: str = SOURCE_CHAT,
+                 source_ref: str | None = None,
+                 created_by: str | None = None) -> tuple[dict, dict]:
+    """对话写回专用的增量更新：props 与现有属性浅合并（None 值删除该键），
+    name 非空才改名。返回 (更新前, 更新后) 行快照供审计。
+
+    与管理端 update_entity 的整包覆盖语义不同：聊天里"记一下王工的电话"
+    不应抹掉他原有的职位等属性。
+    """
+    before = get_entity(tenant_id, id_)
+    if not before:
+        raise ValueError(f"实体 id={id_} 不存在或不属于当前租户")
+    merged = dict(before.get("props") or {})
+    for k, v in (props or {}).items():
+        if v is None:
+            merged.pop(k, None)
+        else:
+            merged[k] = v
+    new_name = (name or "").strip() or before["name"]
+    con = _conn()
+    con.execute(
+        "UPDATE entities SET name=?, props=?, source=?, source_ref=?, created_by=?, "
+        "updated_at=? WHERE id=? AND tenant_id=?",
+        (new_name, json.dumps(merged, ensure_ascii=False), source, source_ref,
+         created_by, _now(), id_, tenant_id))
+    con.commit()
+    con.close()
+    after = get_entity(tenant_id, id_)
+    return before, after
 
 
 def delete_entity(tenant_id: str, id_: int) -> None:
@@ -780,7 +880,18 @@ def list_relations(tenant_id: str, entity_id: int | None = None) -> list[dict]:
     return out
 
 
-def create_relation(tenant_id: str, data: dict) -> int:
+def create_relation(tenant_id: str, data: dict, *, source: str = SOURCE_ADMIN,
+                    source_ref: str | None = None, created_by: str | None = None) -> int:
+    return create_relation_ex(
+        tenant_id, data, source=source, source_ref=source_ref,
+        created_by=created_by)[0]
+
+
+def create_relation_ex(tenant_id: str, data: dict, *, source: str = SOURCE_ADMIN,
+                       source_ref: str | None = None,
+                       created_by: str | None = None) -> tuple[int, bool]:
+    """同 create_relation，额外返回 created 标记：同类型重边命中时 (既有id, False)，
+    真正新建时 (新id, True)。供对话写回区分 no-op，避免幂等重记审计。"""
     from_id, to_id = data.get("from_id"), data.get("to_id")
     rel = (data.get("relation_type") or "").strip()
     if not from_id or not to_id or not rel:
@@ -806,17 +917,25 @@ def create_relation(tenant_id: str, data: dict) -> int:
         raise ValueError(
             f"关系 {rel} 要求 {rt['from_type']} → {rt['to_type']}，"
             f"实际 {from_e['entity_type']} → {to_e['entity_type']}")
+    # 同类型关系边幂等：两两端点已存在同类型未删除边则直接返回既有 id，
+    # 避免对话中重复"记一下"造成重边。
+    existed = con.execute(
+        "SELECT id FROM relations WHERE from_id=? AND to_id=? AND relation_type=? "
+        "AND tenant_id=? AND deleted_at IS NULL",
+        (from_id, to_id, rel, tenant_id)).fetchone()
+    if existed:
+        con.close()
+        return existed["id"], False
     now = _now()
-    con = _conn()
     try:
         rid = dblayer.insert_returning_id(
             con,
-            "INSERT INTO relations(from_id,to_id,relation_type,props,tenant_id,created_at,updated_at)"
-            " VALUES(?,?,?,?,?,?,?)",
+            "INSERT INTO relations(from_id,to_id,relation_type,props,tenant_id,source,"
+            "source_ref,created_by,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?)",
             (from_id, to_id, rel, json.dumps(data.get("props") or {}, ensure_ascii=False),
-             tenant_id, now, now))
+             tenant_id, source, source_ref, created_by, now, now))
         con.commit()
-        return rid
+        return rid, True
     finally:
         con.close()
 

--- a/backend/app/tools/ontology_tools.py
+++ b/backend/app/tools/ontology_tools.py
@@ -1,72 +1,239 @@
 """企业业务本体运行时工具（闭包：绑定当前用户的 tenant_id）。
 
 与 kb_search 同类：不在 ALL_LOCAL_TOOLS 静态登记，由 compiler._assemble_tools
-按用户动态生成，保证查询只落在当前租户的业务数据上。
+按用户动态生成，保证读写只落在当前租户的业务数据上。
 
-两个工具：
-  ontology_find_entities   按实体类型/关键词查业务实体
-  ontology_query_relations 沿实体关系走一跳，返回关联对象
+三个工具：
+  ontology_find_entities    按实体类型/关键词查业务实体
+  ontology_query_relations  沿实体关系走一跳，返回关联对象
+  ontology_write            对话写回（新增/更新实体、建立关系）
+
+装配红线：ontology_write 只有员工在资源中心显式勾选「企业本体写回」时才注入
+（include_write=True）；未授权员工的工具集里根本不存在该工具，模型无法调用。
+每次写回按 source='chat' + 会话 id 溯源，并写审计日志。
 """
 
 import json
+from typing import Any, Optional
 
 from langchain_core.tools import tool
+from langgraph.config import get_config
 
-from app import catalog, ontology
+from app import audit, catalog, ontology
 
 
-def make_ontology_tools(user_id: str | None) -> list:
-    """按用户视角动态生成 ontology_* 工具（业务本体查询，按 tenant 隔离）。"""
+def make_ontology_tools(user_id: str | None, include_reads: bool = True,
+                        include_write: bool = False) -> list:
+    """按用户视角动态生成 ontology_* 工具（按 tenant 隔离）。
+
+    include_reads: 员工声明了任一查询工具时为真，注入两个只读工具。
+    include_write: 仅当员工显式声明 ontology_write 时为真，注入写回工具。
+    """
     tenant = "default"
+    username = ""
     if user_id:
         u = catalog.get_user(user_id)
         if u:
             tenant = u.get("tenant_id") or "default"
+            username = u.get("username") or ""
 
     def _fmt(items: list) -> str:
         if not items:
             return "（未找到相关记录）"
         return json.dumps(items, ensure_ascii=False, indent=1)
 
-    @tool
-    def ontology_find_entities(entity_type: str = "", keyword: str = "") -> str:
-        """【企业业务本体查询】按实体类型和/或关键词查找业务实体。
+    tools = []
 
-        实体类型：org(组织)/department(部门)/position(岗位)/employee(员工)/
-        customer(客户)/contact(客户联系人)/product(产品)/project(项目)/
-        contract(合同)/order(订单)/station(基站)/area(片区)。
-        涉及公司内部的人、部门、客户、联系人、项目、合同、订单、产品信息，或网络运营的
-        基站、片区信息时，先调用本工具拿到实体 id，再配合 ontology_query_relations
-        展开其关联关系。
-        """
-        items = ontology.find_entities(
-            tenant,
-            entity_type=entity_type.strip() or None,
-            keyword=keyword.strip() or None,
-            limit=20,
-        )
-        return _fmt(items)
+    if include_reads:
+        @tool
+        def ontology_find_entities(entity_type: str = "", keyword: str = "") -> str:
+            """【企业业务本体查询】按实体类型和/或关键词查找业务实体。
 
-    @tool
-    def ontology_query_relations(entity_id: int, relation_type: str = "", direction: str = "any") -> str:
-        """【企业业务本体关系查询】沿某实体的关系走一跳，返回其关联对象。
+            实体类型：org(组织)/department(部门)/position(岗位)/employee(员工)/
+            customer(客户)/contact(客户联系人)/product(产品)/project(项目)/
+            contract(合同)/order(订单)/station(基站)/area(片区)。
+            涉及公司内部的人、部门、客户、联系人、项目、合同、订单、产品信息，或网络运营的
+            基站、片区信息时，先调用本工具拿到实体 id，再配合 ontology_query_relations
+            展开其关联关系。
+            """
+            items = ontology.find_entities(
+                tenant,
+                entity_type=entity_type.strip() or None,
+                keyword=keyword.strip() or None,
+                limit=20,
+            )
+            return _fmt(items)
 
-        关系类型：belong_to(隶属于)/belongs_to(属于)/hold_position(担任)/
-        manage(负责)/follow_up(跟进)/serve(服务)/correspond_to(对应)/
-        sign(签约)/decide(决策)/place_order(下单)/include(包含)/
-        cover(基站覆盖片区)/maintain(维护对接)/located_in(客户位于片区)。
-        direction: any/out/in。
-        查询"某人负责哪些项目、跟进哪些客户、某客户签约了哪些合同、
-        某合同包含哪些产品、某商机对应哪份合同、联系人中谁是决策人/技术对接人、
-        某基站覆盖哪些片区"等时使用，可连续多跳（如基站→片区→客户）。
-        通常先 ontology_find_entities 拿到实体 id 再调用本工具。
-        """
-        rows = ontology.query_relations(
-            tenant,
-            entity_id=entity_id,
-            relation_type=relation_type.strip() or None,
-            direction=direction.strip() or "any",
-        )
-        return _fmt(rows)
+        @tool
+        def ontology_query_relations(entity_id: int, relation_type: str = "",
+                                     direction: str = "any") -> str:
+            """【企业业务本体关系查询】沿某实体的关系走一跳，返回其关联对象。
 
-    return [ontology_find_entities, ontology_query_relations]
+            关系类型：belong_to(隶属于)/belongs_to(属于)/hold_position(担任)/
+            manage(负责)/follow_up(跟进)/serve(服务)/correspond_to(对应)/
+            sign(签约)/decide(决策)/place_order(下单)/include(包含)/
+            cover(基站覆盖片区)/maintain(维护对接)/located_in(客户位于片区)。
+            direction: any/out/in。
+            查询"某人负责哪些项目、跟进哪些客户、某客户签约了哪些合同、
+            某合同包含哪些产品、某商机对应哪份合同、联系人中谁是决策人/技术对接人、
+            某基站覆盖哪些片区"等时使用，可连续多跳（如基站→片区→客户）。
+            通常先 ontology_find_entities 拿到实体 id 再调用本工具。
+            """
+            rows = ontology.query_relations(
+                tenant,
+                entity_id=entity_id,
+                relation_type=relation_type.strip() or None,
+                direction=direction.strip() or "any",
+            )
+            return _fmt(rows)
+
+        tools += [ontology_find_entities, ontology_query_relations]
+
+    if include_write:
+        def _conv_id() -> str:
+            """从 LangGraph 运行时配置取当前会话 id（写回归宿），取不到留空。"""
+            try:
+                return (get_config() or {}).get("configurable", {}).get("thread_id", "") or ""
+            except Exception:
+                return ""
+
+        def _audit(action: str, obj_type: str, obj_id, before, after) -> None:
+            # 审计旁路：写失败不阻断业务（audit.log 内部已吞异常）。
+            audit.log(action=action, obj_type=obj_type, obj_id=str(obj_id or ""),
+                      admin={"id": user_id or "", "username": username},
+                      before=before, after=after)
+
+        @tool
+        def ontology_write(
+            op: str,
+            entity_type: str = "",
+            name: str = "",
+            entity_id: int = 0,
+            props: Optional[dict[str, Any]] = None,
+            relation_type: str = "",
+            from_id: int = 0,
+            to_id: int = 0,
+            from_type: str = "",
+            from_name: str = "",
+            to_type: str = "",
+            to_name: str = "",
+            rel_props: Optional[dict[str, Any]] = None,
+        ) -> str:
+            """【企业业务本体写回】把用户在对话中明确陈述的业务事实写入企业本体
+            （全企业共享，其他数字员工也能查到），并自动记录来源会话与操作审计。
+
+            仅在用户明确要求"记一下/记录/更新/新增/把…录到本体/建立…关系"时调用；
+            只写用户亲口确认的事实，禁止推测或补全，信息不全先向用户追问确认。
+            写之前先用 ontology_find_entities 查一下，避免重复新建。
+
+            op 支持三种操作：
+            - create_entity：新增实体。参数 entity_type（如 employee/customer/contact/
+              project/contract/product/station/area 等）、name、props（属性对象）。
+              同类型下已存在同名实体时会拒绝，提示改用 update_entity。
+            - update_entity：更新实体（属性按 key 合并，不会抹掉其他属性）。
+              参数 entity_id（必填，先 find 拿到）、props（要更新的属性，如
+              {"title": "信息化部副总监"}）、name（可选，改名时传）。
+            - create_relation：在两个实体间建立关系边。relation_type 必填
+              （如 follow_up 跟进/manage 负责/belongs_to 属于/hold_position 担任/
+              serve 服务/include 包含/correspond_to 对应/maintain 维护/cover 覆盖）。
+              端点用 id 指定：from_id/to_id；或用类型+名称指定：
+              from_type+from_name、to_type+to_name（自动解析，歧义会报错）。
+              端点类型必须符合该关系的 schema 约束，同类型重边自动去重。
+
+            返回 JSON：ok=true 时带写入结果；ok=false 时 error 说明原因（可据以纠正参数
+            或向用户澄清），不要把失败当成功告知用户。
+            """
+            ref = _conv_id()
+            common = dict(source=ontology.SOURCE_CHAT, source_ref=ref,
+                          created_by=user_id)
+            try:
+                if op == "create_entity":
+                    etype = entity_type.strip()
+                    ename = name.strip()
+                    if not etype or not ename:
+                        raise ValueError("create_entity 需要 entity_type 与 name")
+                    existed = ontology.find_entities(
+                        tenant, entity_type=etype, keyword=ename, limit=20)
+                    dup = [e for e in existed if e.get("name") == ename]
+                    if dup:
+                        raise ValueError(
+                            f"已存在 {etype}「{ename}」(id={dup[0]['id']})，"
+                            "更新信息请用 op=update_entity")
+                    new_id = ontology.create_entity(
+                        tenant,
+                        {"entity_type": etype, "name": ename,
+                         "props": props or {}},
+                        **common)
+                    after = ontology.get_entity(tenant, new_id)
+                    _audit("chat_create_entity", "ontology_entity", new_id, None, after)
+                    return json.dumps(
+                        {"ok": True, "op": op, "id": new_id, "entity": after,
+                         "message": f"已新增 {etype}「{ename}」并记录到企业本体"},
+                        ensure_ascii=False)
+
+                if op == "update_entity":
+                    if not entity_id:
+                        raise ValueError("update_entity 需要 entity_id"
+                                         "（先 ontology_find_entities 查询）")
+                    before, after = ontology.patch_entity(
+                        tenant, entity_id, props=props, name=name.strip() or None,
+                        **common)
+                    _audit("chat_update_entity", "ontology_entity", entity_id,
+                           before, after)
+                    return json.dumps(
+                        {"ok": True, "op": op, "id": entity_id, "before": before,
+                         "after": after,
+                         "message": f"已更新实体「{after['name']}」的信息"},
+                        ensure_ascii=False)
+
+                if op == "create_relation":
+                    rel = relation_type.strip()
+                    if not rel:
+                        raise ValueError("create_relation 需要 relation_type")
+                    fid, tid = from_id, to_id
+                    f_desc = t_desc = ""
+                    if not fid:
+                        src = ontology.resolve_entity(
+                            tenant, from_type.strip(), from_name.strip())
+                        fid = src["id"]
+                        f_desc = f"{src['entity_type']}:{src['name']}"
+                    if not tid:
+                        dst = ontology.resolve_entity(
+                            tenant, to_type.strip(), to_name.strip())
+                        tid = dst["id"]
+                        t_desc = f"{dst['entity_type']}:{dst['name']}"
+                    new_id, created = ontology.create_relation_ex(
+                        tenant,
+                        {"from_id": fid, "to_id": tid, "relation_type": rel,
+                         "props": rel_props or {}},
+                        **common)
+                    after = {"id": new_id, "from_id": fid, "to_id": tid,
+                             "relation_type": rel, "from": f_desc, "to": t_desc}
+                    # 幂等重边是 no-op：不重复记审计，回复中如实说明已存在。
+                    if created:
+                        _audit("chat_create_relation", "ontology_relation", new_id,
+                               None, after)
+                        message = f"已建立关系 {rel}（{f_desc or fid} → {t_desc or tid}）"
+                    else:
+                        message = (f"关系 {rel}（{f_desc or fid} → {t_desc or tid}）"
+                                   "已存在，无需重复建立")
+                    return json.dumps(
+                        {"ok": True, "op": op, "id": new_id, "created": created,
+                         "relation": after, "message": message},
+                        ensure_ascii=False)
+
+                raise ValueError(
+                    f"未知 op={op}，支持 create_entity / update_entity / create_relation")
+            except ValueError as e:
+                return json.dumps({"ok": False, "op": op, "error": str(e)},
+                                  ensure_ascii=False)
+            except Exception as e:  # 写回失败要让模型可解释，不把异常抛断对话
+                print(f"[ontology_write] 写回失败: {type(e).__name__}: {e}")
+                return json.dumps(
+                    {"ok": False, "op": op,
+                     "error": f"写回失败：{type(e).__name__}: {e}"},
+                    ensure_ascii=False)
+
+        tools.append(ontology_write)
+
+    return tools

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -213,3 +213,183 @@ def test_netops_demo_seed_skips_when_station_exists():
     ontology.seed_netops_demo_if_empty()
     assert ontology.find_entities("default", entity_type="customer", keyword="星联") == []
     assert ontology.find_entities("default", entity_type="org", keyword="星联") == []
+
+
+# ---------------- 对话写回（ontology_write / source 溯源） ----------------
+
+def test_seed_rows_default_source_and_migration_idempotent():
+    """老库迁移补列后，种子数据 source=seed；init 重复执行不报错。"""
+    ontology.init()
+    ontology.init()  # 幂等
+    ontology.seed_schema_if_empty()
+    ontology.seed_demo_if_empty()
+    lx = ontology.find_entities("default", entity_type="employee", keyword="李晓芳")[0]
+    row = ontology.get_entity("default", lx["id"])
+    assert row["source"] == "seed"
+    assert row["source_ref"] is None and row["created_by"] is None
+    rels = ontology.list_relations("default", lx["id"])
+    assert rels and all(r["source"] == "seed" for r in rels)
+
+
+def test_patch_entity_merges_props_and_tags_chat_source():
+    """聊天写回的增量更新：props 浅合并不抹其他字段，None 删键，溯源三列落标。"""
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    eid = ontology.create_entity("default", {
+        "entity_type": "employee", "name": "王工",
+        "props": {"title": "网络运维主管", "phone": "13900000000"}})
+
+    before, after = ontology.patch_entity(
+        "default", eid, {"title": "信息化部副总监", "phone": None},
+        source=ontology.SOURCE_CHAT, source_ref="conv-1", created_by="u1")
+
+    assert before["props"]["title"] == "网络运维主管"
+    assert after["props"]["title"] == "信息化部副总监"
+    assert "phone" not in after["props"]
+    assert after["source"] == "chat"
+    assert after["source_ref"] == "conv-1"
+    assert after["created_by"] == "u1"
+
+
+def test_resolve_entity_exact_fuzzy_and_ambiguous():
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    ontology.create_entity("default", {"entity_type": "customer", "name": "杭州智造科技"})
+    ontology.create_entity("default", {"entity_type": "customer", "name": "杭州物流科技"})
+
+    # 精确名优先
+    assert ontology.resolve_entity("default", "customer", "杭州智造科技")["name"] == "杭州智造科技"
+    # 唯一包含匹配（忽略大小写）
+    assert ontology.resolve_entity("default", "customer", "智造")["name"] == "杭州智造科技"
+    # 歧义 / 未命中报错
+    try:
+        ontology.resolve_entity("default", "customer", "杭州")
+        assert False, "多候选应歧义报错"
+    except ValueError as e:
+        assert "多个" in str(e)
+    try:
+        ontology.resolve_entity("default", "customer", "不存在的客户")
+        assert False, "0 候选应报错"
+    except ValueError:
+        pass
+
+
+def test_chat_create_relation_tagged_and_idempotent():
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    emp = ontology.create_entity("default", {"entity_type": "employee", "name": "测试员工"})
+    cus = ontology.create_entity("default", {"entity_type": "customer", "name": "测试客户"})
+    rid = ontology.create_relation(
+        "default", {"from_id": emp, "to_id": cus, "relation_type": "follow_up"},
+        source=ontology.SOURCE_CHAT, source_ref="conv-9", created_by="u2")
+    again = ontology.create_relation(
+        "default", {"from_id": emp, "to_id": cus, "relation_type": "follow_up"},
+        source=ontology.SOURCE_CHAT)
+    assert rid == again  # 同类型重边去重
+    rows = ontology.list_relations("default", cus)
+    assert len(rows) == 1 and rows[0]["source"] == "chat"
+    assert rows[0]["source_ref"] == "conv-9" and rows[0]["created_by"] == "u2"
+
+
+def test_ontology_write_tool_gate():
+    """未授权（include_write=False）工具集里不存在 ontology_write。"""
+    from app.tools.ontology_tools import make_ontology_tools
+    ontology.init()
+    assert "ontology_write" not in {t.name for t in make_ontology_tools(None)}
+    assert "ontology_write" not in {
+        t.name for t in make_ontology_tools(None, include_reads=True, include_write=False)}
+    writable = {t.name for t in make_ontology_tools(
+        None, include_reads=True, include_write=True)}
+    assert {"ontology_find_entities", "ontology_query_relations", "ontology_write"} <= writable
+
+
+def test_ontology_write_tool_full_flow_and_audit():
+    """工具级闭环：新增→查重拒绝→合并更新→按名建关系→重边去重 + 审计 + 溯源。"""
+    import json as _json
+    from app import audit, catalog
+    from app.tools.ontology_tools import make_ontology_tools
+
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    ontology.seed_demo_if_empty()
+    uid = catalog.create_user("alice", "hash", tenant_id="default")
+    tools = {t.name: t for t in make_ontology_tools(uid, include_write=True)}
+    wt = tools["ontology_write"]
+    cfg = {"configurable": {"thread_id": "conv-77"}}
+
+    # 1) 新增实体
+    r = _json.loads(wt.invoke({
+        "op": "create_entity", "entity_type": "customer",
+        "name": "写回测试客户", "props": {"grade": "A级"}}, config=cfg))
+    assert r["ok"] is True
+    cid = r["id"]
+    row = ontology.get_entity("default", cid)
+    assert row["source"] == "chat" and row["source_ref"] == "conv-77"
+    assert row["created_by"] == uid and row["props"]["grade"] == "A级"
+
+    # 2) 同名重复新增被拒（提示走 update）
+    dup = _json.loads(wt.invoke({"op": "create_entity", "entity_type": "customer",
+                                 "name": "写回测试客户"}, config=cfg))
+    assert dup["ok"] is False and "update_entity" in dup["error"]
+
+    # 3) 合并更新：原属性保留，新属性并入
+    upd = _json.loads(wt.invoke({
+        "op": "update_entity", "entity_id": cid,
+        "props": {"contact": "张工"}}, config=cfg))
+    assert upd["ok"] is True
+    row = ontology.get_entity("default", cid)
+    assert row["props"] == {"grade": "A级", "contact": "张工"}
+
+    # 4) 按类型+名称建关系（李晓芳 follow_up 写回测试客户）
+    rel = _json.loads(wt.invoke({
+        "op": "create_relation", "relation_type": "follow_up",
+        "from_type": "employee", "from_name": "李晓芳",
+        "to_type": "customer", "to_name": "写回测试客户"}, config=cfg))
+    assert rel["ok"] is True and rel["created"] is True
+    rid = rel["id"]
+    # 再来一次：同类型重边去重，返回同一 id 且 created=false（no-op 不记审计）
+    rel2 = _json.loads(wt.invoke({
+        "op": "create_relation", "relation_type": "follow_up",
+        "from_type": "employee", "from_name": "李晓芳",
+        "to_type": "customer", "to_name": "写回测试客户"}, config=cfg))
+    assert rel2["ok"] is True and rel2["id"] == rid and rel2["created"] is False
+    assert len(ontology.list_relations("default", cid)) == 1
+
+    # 5) schema 类型不符 → ok=false（customer→employee 的 follow_up 非法）
+    bad = _json.loads(wt.invoke({
+        "op": "create_relation", "relation_type": "follow_up",
+        "from_type": "customer", "from_name": "写回测试客户",
+        "to_type": "employee", "to_name": "李晓芳"}, config=cfg))
+    assert bad["ok"] is False and "要求" in bad["error"]
+
+    # 6) 未知 op / 缺参 → ok=false
+    assert _json.loads(wt.invoke({"op": "drop_all"}, config=cfg))["ok"] is False
+    assert _json.loads(wt.invoke({"op": "update_entity"}, config=cfg))["ok"] is False
+
+    # 7) 审计日志齐全（实体 2 条 + 关系 1 条），操作人为当前用户
+    ent_logs, ent_total = audit.list_logs(obj_type="ontology_entity", limit=50)
+    rel_logs, rel_total = audit.list_logs(obj_type="ontology_relation", limit=50)
+    assert ent_total == 2 and rel_total == 1
+    assert {l["action"] for l in ent_logs} == {"chat_create_entity", "chat_update_entity"}
+    assert rel_logs[0]["action"] == "chat_create_relation"
+    assert all(l["actor_id"] == uid for l in ent_logs + rel_logs)
+
+
+def test_ontology_write_tool_respects_tenant_isolation():
+    """跨租户写回：看不到别租户实体，名称解析失败、写不进对方数据。"""
+    import json as _json
+    from app import catalog
+    from app.tools.ontology_tools import make_ontology_tools
+
+    ontology.init()
+    ontology.seed_schema_if_empty()
+    ontology.seed_demo_if_empty()
+    uid_b = catalog.create_user("bob", "hash", tenant_id="tenant-b")
+    wt = {t.name: t for t in make_ontology_tools(uid_b, include_write=True)}["ontology_write"]
+
+    r = _json.loads(wt.invoke({
+        "op": "create_relation", "relation_type": "follow_up",
+        "from_type": "employee", "from_name": "李晓芳",
+        "to_type": "customer", "to_name": "华芯半导体"}))
+    assert r["ok"] is False and "未找到" in r["error"]
+    assert ontology.stats("tenant-b")["total_entities"] == 0


### PR DESCRIPTION
## 变更内容

本体深化阶段 1 第一项：授权员工在对话中把用户明确陈述的业务事实写回企业本体（全企业共享），实现「对话即录入」。

### 数据层（backend/app/ontology.py）
- entities/relations 新增溯源三列：`source`（seed/admin/chat/import）、`source_ref`（来源会话 id）、`created_by`（操作人）；启动幂等 ALTER 补列（PG/sqlite 双方言），存量数据自动标 seed
- 新增写回原语：
  - `patch_entity`：props 按 key 浅合并（None 删键），「记一下电话」不会抹掉职位等其他属性，区别于管理端整包覆盖
  - `resolve_entity`：名称解析（精确名优先 → 唯一模糊匹配 → 歧义/未命中报错并给候选）
- `create_relation_ex` 返回是否真新建：同类型重边幂等去重，no-op 不重记审计

### 工具层（backend/app/tools/ontology_tools.py）
- 新闭包工具 `ontology_write`（与 kb_search 同类，不进 ALL_LOCAL_TOOLS），三操作：
  - `create_entity`：同名查重，已存在则拒绝并提示走 update
  - `update_entity`：合并更新，返回 before/after 快照
  - `create_relation`：端点可用 id 或「类型+名称」指定，自动解析；复用既有 schema 两端类型校验
- 运行时从 LangGraph config 取 thread_id 落 `source_ref`；每次写回写 catalog 审计日志（含 before/after）
- 失败返回 `ok:false` 结构化错误（不抛异常断对话），docstring 明确要求模型不得把失败当成功
- **授权红线**：`ontology_write` 独立授权，未授权员工编译时工具集里根本不存在该工具，模型无法调用

### 接线（compiler.py + catalog/seeds.py）
- 默认仅授权 **xiaoxiao（客户事实）+ hrbp（员工事实）**；新库种子随员工播种
- 老库 `backfill_ontology_tools()` 幂等补工具登记与指派（其余内置员工不补）
- system prompt 写回规程按授权挂载（只写用户亲口确认事实、先查重、歧义要确认、失败不许谎报）
- 资源中心工具列表数据驱动，零前端改动即出现「企业本体写回」开关

### 招牌演示
对 HRBP 说「记一下，王工升职为信息化部副总监」→ 下一轮问「王工什么职位」，答案来自本体而非模型记忆，审计页可查来源会话。

## 测试与验证

- [x] 新增 7 个用例：迁移幂等与 seed 溯源默认值、props 合并更新与溯源落标、名称解析（精确/模糊/歧义/未命中）、关系写回去重、工具授权闸门、工具级全流程（新增→查重拒绝→合并更新→按名建边→schema 拒绝→审计齐全）、跨租户写回隔离 —— `pytest tests/test_ontology.py` 16 个用例全绿
- [x] 全量 pytest（剔除既有环境性失败文件）全绿；失败清单与 main 基线逐一对比一致（均为既有登录 401/429、playwright 类环境失败）
- [x] 编译器装配冒烟：授权员工实际装配 ontology_write 且 prompt 挂写回规程；未授权员工不注入
- [x] 老库 backfill 冒烟：模拟老库删登记后 backfill，只补 xiaoxiao/hrbp
- [x] 无前端改动，vite build 不受影响；APP_VERSION 未动（版本号按发布流程待发布确认时统一 bump）